### PR TITLE
fix: fix --param typo and add Goose error detection

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -189,15 +189,51 @@ jobs:
         id: goose
         run: |
           echo "Starting Goose implementation..."
-          
-          # Use the implementation recipe with the spec file as parameter
+
+          # Run Goose with the implementation recipe.
+          # set +e so we capture exit code even if non-zero.
+          set +e
           goose run \
             --no-session \
             --recipe .github/goose-recipes/wgmesh-implementation.yaml \
-            --param spec_file="specs/issue-${{ steps.spec.outputs.issue_number }}-spec.md" \
+            --params spec_file="specs/issue-${{ steps.spec.outputs.issue_number }}-spec.md" \
             2>&1 | tee /tmp/goose-output.log
+          GOOSE_EXIT=$?
+          set -e
 
-          echo "Goose finished with exit code: $?"
+          echo "Goose finished with exit code: $GOOSE_EXIT"
+
+          # Detect silent failures: Goose often exits 0 even on errors
+          ERRORS_FOUND=false
+
+          if grep -qiE "rate.?limit|quota.?exceeded|resource.?exhausted|429|too many requests" /tmp/goose-output.log; then
+            echo "::error::Goose hit API rate limits or quota exhaustion"
+            ERRORS_FOUND=true
+          fi
+
+          if grep -qiE "unauthorized|authentication|invalid.?api.?key|403|401" /tmp/goose-output.log; then
+            echo "::error::Goose encountered authentication/authorization errors"
+            ERRORS_FOUND=true
+          fi
+
+          if grep -qi "unexpected argument" /tmp/goose-output.log; then
+            echo "::error::Goose CLI argument error detected"
+            ERRORS_FOUND=true
+          fi
+
+          # Check if output is suspiciously short (Goose didn't actually run)
+          LINES=$(wc -l < /tmp/goose-output.log)
+          if [ "$LINES" -lt 5 ]; then
+            echo "::error::Goose output is suspiciously short ($LINES lines) — likely did not execute"
+            ERRORS_FOUND=true
+          fi
+
+          if [ "$GOOSE_EXIT" -ne 0 ] || [ "$ERRORS_FOUND" = "true" ]; then
+            echo "::error::Goose failed (exit=$GOOSE_EXIT, errors_detected=$ERRORS_FOUND)"
+            echo "--- Last 50 lines of Goose output ---"
+            tail -50 /tmp/goose-output.log
+            exit 1
+          fi
 
       # ── Commit and push ────────────────────────────────
       - name: Check for changes and commit


### PR DESCRIPTION
## Summary

- Fix `--param` → `--params` (Goose CLI requires plural form)
- Add error pattern detection for rate limits, auth failures, CLI arg errors
- Add output length check to catch Goose not executing
- Goose CLI exits 0 even on errors; this ensures the workflow fails properly

## Root Cause

The `--param` typo caused Goose to silently fail on PR #28 (issue #24 macOS builds spec). The workflow reported "success" with "no code changes" when Goose actually never ran:

```
error: unexpected argument '--param' found
  tip: a similar argument exists: '--params'
```

Goose exited with code 0 despite the error, so the workflow didn't detect the failure.

## Error Detection

The new error detection catches:
- Rate limit / quota exhaustion errors
- Authentication / authorization failures  
- CLI argument errors (like this `--param` typo)
- Suspiciously short output (< 5 lines = Goose didn't run)

## Template Sync

The same error detection has been pushed to `ai-pipeline-template` in commit `caf015e`.