### PR TITLE
fix: switch Goose from recipe to instructions file

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -229,19 +229,73 @@ jobs:
           git checkout -b "$BRANCH"
           echo "Created branch: $BRANCH"
 
+      # ── Build Goose instructions ─────────────────────────
+      - name: Build Goose instructions
+        run: |
+          ISSUE_NUM="${{ steps.spec.outputs.issue_number }}"
+          SPEC_FILE="specs/issue-${ISSUE_NUM}-spec.md"
+
+          cat > /tmp/goose-task.md << 'TASK_HEADER'
+          # Implementation Task for wgmesh
+
+          You are implementing code changes for the wgmesh project.
+          wgmesh is a Go 1.23 WireGuard mesh network builder.
+
+          ## Project Rules
+
+          - Language: Go 1.23, module: github.com/atvirokodosprendimai/wgmesh
+          - Build: `go build` (must succeed)
+          - Test: `go test ./...` (must pass)
+          - Lint: `go vet ./...` (must be clean)
+          - Format: code must be `gofmt` formatted
+          - Always handle errors with context wrapping
+          - Use standard library where possible
+          - Do NOT modify files outside the scope of the specification below
+
+          ## Specification
+
+          TASK_HEADER
+
+          # Append the actual spec content
+          cat "$SPEC_FILE" >> /tmp/goose-task.md
+
+          cat >> /tmp/goose-task.md << 'TASK_FOOTER'
+
+          ## Implementation Checklist
+
+          Follow these steps in order:
+
+          1. Read the specification above thoroughly
+          2. Explore the relevant source files mentioned in "Affected Files"
+          3. Implement the changes described in "Proposed Approach"
+          4. Write or update unit tests for your changes
+          5. Run `go build` and fix any compilation errors
+          6. Run `go test ./...` and fix any test failures
+          7. Run `go vet ./...` and fix any issues
+          8. Run `gofmt -l .` to verify formatting (fix with `gofmt -w .` if needed)
+          9. Keep changes minimal and focused - do not refactor unrelated code
+
+          IMPORTANT: If the spec classification is "wont-do" or "needs-info",
+          do NOT implement anything. Just create a brief note explaining why.
+          TASK_FOOTER
+
+          echo "Goose instructions written to /tmp/goose-task.md"
+          wc -l /tmp/goose-task.md
+
       # ── Run Goose ──────────────────────────────────────
       - name: Run Goose
         id: goose
         run: |
           echo "Starting Goose implementation..."
 
-          # Run Goose with the implementation recipe.
-          # set +e so we capture exit code even if non-zero.
+          # max-turns limits LLM round-trips to control API costs.
+          # 50 is generous for most tasks; reduce if using paid-tier models.
           set +e
           goose run \
             --no-session \
-            --recipe .github/goose-recipes/wgmesh-implementation.yaml \
-            --params spec_file="specs/issue-${{ steps.spec.outputs.issue_number }}-spec.md" \
+            --with-builtin "developer" \
+            -i /tmp/goose-task.md \
+            --max-turns 50 \
             2>&1 | tee /tmp/goose-output.log
           GOOSE_EXIT=$?
           set -e


### PR DESCRIPTION
## Summary

Goose v1.24.0 rejects the recipe parameter definitions we were using:
```
Error: Invalid recipe: 
Unnecessary parameter definitions: spec_file.
```

This switches from `--recipe` + `--params` to `-i` (instructions file) + `--with-builtin developer`:

- Builds a task file at `/tmp/goose-task.md` with project rules + spec content inlined
- Uses `--max-turns 50` to limit API costs
- Compatible with current and future Goose versions
- Removes runtime dependency on recipe parameter parsing

## Context

This is the third fix in the Goose pipeline series:
- PR #29: Error detection (merged)
- PR #30: workflow_dispatch + --param typo fix (merged) 
- **This PR**: Recipe → instructions file (Goose v1.24.0 compatibility)

After this merges, I'll re-trigger Goose for issue #24 via workflow_dispatch.