### PR TITLE
fix: switch Goose model to GLM-4.7

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -25,7 +25,7 @@ permissions:
 
 env:
   GOOSE_PROVIDER: anthropic
-  GOOSE_MODEL: GLM-5
+  GOOSE_MODEL: GLM-4.7
   ANTHROPIC_API_KEY: ${{ secrets.ZAI_API_KEY }}
   ANTHROPIC_HOST: https://api.z.ai/api/anthropic
 


### PR DESCRIPTION
GLM-5 viewed files but never wrote changes. GLM-4.7 is z.ai's tested model for Goose.