### PR TITLE
feat: auto-undraft Copilot coding agent PRs

### DIFF
--- a/.github/workflows/copilot-undraft.yml
+++ b/.github/workflows/copilot-undraft.yml
@@ -1,0 +1,38 @@
+name: Auto-undraft Copilot PRs
+
+# When Copilot coding agent opens a draft PR, automatically mark it
+# ready for review so automated code review and the /approve flow work.
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  undraft:
+    if: >-
+      github.event.pull_request.draft == true &&
+      github.event.pull_request.user.login == 'copilot-swe-agent[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark PR ready for review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PUSH_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const prNodeId = context.payload.pull_request.node_id;
+
+            console.log(`Copilot draft PR #${prNumber} detected, marking ready for review`);
+
+            await github.graphql(`
+              mutation($id: ID!) {
+                markPullRequestReadyForReview(input: {pullRequestId: $id}) {
+                  pullRequest { isDraft }
+                }
+              }
+            `, { id: prNodeId });
+
+            console.log(`PR #${prNumber} marked ready for review`);


### PR DESCRIPTION
## Summary

- Copilot coding agent creates draft PRs by default
- This prevents automated code review from running and blocks the `/approve` flow
- New workflow auto-marks Copilot draft PRs as ready-for-review when opened
- Only triggers for PRs authored by `copilot-swe-agent[bot]`