### PR TITLE
spec: Issue #60 - Optimize Docker build times

### DIFF
--- a/specs/issue-60-spec.md
+++ b/specs/issue-60-spec.md
@@ -1,0 +1,50 @@
+# Specification: Issue #60
+
+## Classification
+feature
+
+## Deliverables
+code (build infrastructure only — no Go code changes)
+
+## Problem Analysis
+
+Docker builds currently take ~8 minutes for every run, including PR validation builds that never push an image. The bottleneck is QEMU-emulated multi-arch builds (`linux/amd64,linux/arm64,linux/arm/v7`) running even on PRs where only a compile check is needed.
+
+## Proposed Approach
+
+### 1. Workflow changes (`docker-build.yml`)
+
+- Skip QEMU setup on PRs (`if: github.event_name != 'pull_request'`)
+- Build only `linux/amd64` on PRs; keep full multi-arch on push/tag:
+  ```yaml
+  platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
+  ```
+- Bump `docker/build-push-action` from v5 to v6
+
+### 2. Dockerfile improvements
+
+- Add `# syntax=docker/dockerfile:1.7` directive to enable BuildKit features
+- Use `--mount=type=cache,target=/go/pkg/mod` on `go mod download` for module cache
+- Use `--mount=type=cache,target=/go/pkg/mod` and `--mount=type=cache,target=/root/.cache/go-build` on `go build` for build cache
+- Replace `-a -installsuffix cgo` with `-trimpath` (the former is redundant with `CGO_ENABLED=0`, the latter improves reproducibility)
+- Remove redundant `apk update` (already using `--no-cache`)
+- Remove redundant `chmod +x` (binary is already executable from `go build`)
+
+### 3. `.dockerignore` update
+
+- Add `.github` to exclude workflows/templates from Docker build context
+
+## Affected Files
+
+- `.github/workflows/docker-build.yml`
+- `Dockerfile`
+- `.dockerignore`
+
+## Test Strategy
+
+1. Open the PR and verify the Docker build on the PR runs in ~1-2 min (amd64 only, no QEMU)
+2. After merge, verify a push build still produces multi-arch images
+3. Verify GHA cache hits on subsequent builds
+
+## Estimated Complexity
+low


### PR DESCRIPTION
## Summary

Specification for optimizing Docker build times (Issue #60).

- Skip QEMU + multi-arch on PR builds (amd64-only validation)
- Add BuildKit mount caches to Dockerfile for faster rebuilds
- Exclude `.github/` from Docker build context

**Expected impact:** PR Docker builds drop from ~8 min → ~1-2 min.

This is a spec-only PR — no implementation code. Approve to trigger Goose implementation.