### PR TITLE
fix: board-sync GraphQL query bug — unused $projectId variable

### DIFF
--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -78,7 +78,7 @@ jobs:
 
             // Find or add the item on the project board
             const { node } = await github.graphql(`
-              query($nodeId: ID!, $projectId: ID!) {
+              query($nodeId: ID!) {
                 node(id: $nodeId) {
                   ... on Issue {
                     projectItems(first: 10) {
@@ -98,7 +98,7 @@ jobs:
                   }
                 }
               }
-            `, { nodeId, projectId });
+            `, { nodeId });
 
             let projectItemId = null;
             const items = node?.projectItems?.nodes || [];


### PR DESCRIPTION
## Summary

- Removes unused `$projectId` variable from the `projectItems` lookup query in `board-sync.yml`
- The variable was declared in the query signature but never referenced in the query body
- GitHub's GraphQL API rejects queries with declared-but-unused variables

## Root cause

Both board-sync runs since PR #64 merged failed with:
```
Variable $projectId is declared by anonymous query but not used
```

The `projectId` is used later in JS to filter results, but shouldn't be passed as a GraphQL variable.