### PR TITLE
fix: remove noisy Docker image tags (v0, v0.0, sha-xxx)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,9 +52,6 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            type=sha
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary

Removes 3 tag patterns from `docker-build.yml` metadata:
- `type=semver,pattern=v{{major}}.{{minor}}` — produced `v0.0` (confusing floating alias)
- `type=semver,pattern=v{{major}}` — produced `v0` (same)
- `type=sha` — produced `sha-b28c203` (noise)

**After:** release tags are `v0.0.2` + `latest`, main pushes are `main`. Clean.

Visibility (private → public) is a manual package settings change, not part of this PR.

Fixes #66