### PR TITLE
fix: auto-add items to board on open + skip binary builds on PRs

### DIFF
--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -6,9 +6,9 @@ name: Sync Board Status
 
 on:
   issues:
-    types: [labeled, closed, reopened]
+    types: [opened, labeled, closed, reopened]
   pull_request:
-    types: [labeled, closed, reopened]
+    types: [opened, labeled, closed, reopened]
 
 env:
   PROJECT_ID: "PVT_kwDODz4fRs4BPUe4"
@@ -66,9 +66,11 @@ jobs:
               }
             }
 
-            // Reopened items with no matching label go back to Triage
-            if (!targetCol && context.payload.action === 'reopened') {
-              targetCol = process.env.COL_TRIAGE;
+            // Newly opened/reopened items with no matching label:
+            //   issues → Triage, PRs → Review Code
+            if (!targetCol && (context.payload.action === 'opened' || context.payload.action === 'reopened')) {
+              const isPR = !!context.payload.pull_request;
+              targetCol = isPR ? process.env.COL_REVIEW_CODE : process.env.COL_TRIAGE;
             }
 
             if (!targetCol) {


### PR DESCRIPTION
## Summary

Two changes to reduce noise:

### 1. Auto-add new issues/PRs to board
- New issues → **Triage**
- New PRs → **Review Code**
- Labels still override when the pipeline kicks in

### 2. Skip binary builds on PRs
- `binary-build.yml` no longer triggers on `pull_request`
- Still runs on push to main and version tags
- Docker build still runs on PRs (validates Dockerfile changes)

**Before:** 6 workflows per PR
**After:** 4 workflows per PR (board-sync, docker-build, CodeQL, approve-build)