### PR TITLE
fix: use pull_request_target for workflows safe to run on Copilot PRs

### DIFF
--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -7,7 +7,7 @@ name: Sync Board Status
 on:
   issues:
     types: [opened, labeled, closed, reopened]
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, closed, reopened]
 
 env:

--- a/.github/workflows/copilot-undraft.yml
+++ b/.github/workflows/copilot-undraft.yml
@@ -4,7 +4,7 @@ name: Auto-undraft Copilot PRs
 # ready for review so automated code review and the /approve flow work.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:


### PR DESCRIPTION
## Summary
- Switch `board-sync.yml` and `copilot-undraft.yml` from `pull_request` to `pull_request_target`
- Fixes workflows getting stuck in "action required" on Copilot coding agent PRs

## Why
Copilot coding agent is treated as an outside collaborator by GitHub Actions. Workflows triggered by `pull_request` require manual approval before running. `pull_request_target` runs in the context of the base branch and always executes regardless of approval settings.

## Safety
Both workflows are safe for `pull_request_target`:
- Neither uses `actions/checkout` (no untrusted code execution)
- Both only perform GraphQL API mutations via `actions/github-script`
- `github.event.pull_request` payload is identical between both event types

## Not changed
- `docker-build.yml` — builds PR code, so `action_required` is the correct security behavior

Fixes #79