### PR TITLE
fix: correct mock argument index in TestSetInterfaceAddress_Darwin

### DIFF
--- a/pkg/daemon/helpers_test.go
+++ b/pkg/daemon/helpers_test.go
@@ -407,14 +407,14 @@ func TestSetInterfaceAddress_Darwin(t *testing.T) {
 						}
 					}
 					if name == "route" && len(args) >= 3 {
-						if args[2] == "add" {
+						if args[1] == "add" {
 							return &MockCommand{
 								combinedOutputFunc: func() ([]byte, error) {
 									return tt.routeAddOutput, tt.routeAddErr
 								},
 							}
 						}
-						if args[2] == "change" {
+						if args[1] == "change" {
 							return &MockCommand{
 								combinedOutputFunc: func() ([]byte, error) {
 									return tt.routeChangeOutput, tt.routeChangeErr


### PR DESCRIPTION
## Summary

Fixes the mock executor in `TestSetInterfaceAddress_Darwin` which checked `args[2]` for the route command verb, but the actual implementation at `helpers.go:186` passes args as `"-n", "add", "-net", ...` — making the verb at `args[1]`, not `args[2]`.

## Changes

- `pkg/daemon/helpers_test.go`: Changed `args[2]` to `args[1]` for both `"add"` and `"change"` checks in the mock command executor (lines 410, 417)

## Testing

All 7 subtests in `TestSetInterfaceAddress_Darwin` now pass. Full test suite green.

Fixes #98