### PR TITLE
fix: replace bare exec.Command with cmdExecutor in routes and systemd (fixes #99)

### DIFF
--- a/pkg/daemon/routes_test.go
+++ b/pkg/daemon/routes_test.go
@@ -1,0 +1,265 @@
+package daemon
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestCalculateRouteDiff verifies add/remove logic without any exec calls.
+func TestCalculateRouteDiff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		current       []routeEntry
+		desired       []routeEntry
+		wantAddLen    int
+		wantRemoveLen int
+	}{
+		{
+			name:          "empty both",
+			current:       nil,
+			desired:       nil,
+			wantAddLen:    0,
+			wantRemoveLen: 0,
+		},
+		{
+			name:    "add new route",
+			current: nil,
+			desired: []routeEntry{
+				{Network: "192.168.1.0/24", Gateway: "10.0.0.1"},
+			},
+			wantAddLen:    1,
+			wantRemoveLen: 0,
+		},
+		{
+			name: "remove stale route",
+			current: []routeEntry{
+				{Network: "192.168.1.0/24", Gateway: "10.0.0.1"},
+			},
+			desired:       nil,
+			wantAddLen:    0,
+			wantRemoveLen: 1,
+		},
+		{
+			name: "no change when identical",
+			current: []routeEntry{
+				{Network: "192.168.1.0/24", Gateway: "10.0.0.1"},
+			},
+			desired: []routeEntry{
+				{Network: "192.168.1.0/24", Gateway: "10.0.0.1"},
+			},
+			wantAddLen:    0,
+			wantRemoveLen: 0,
+		},
+		{
+			name: "gateway change triggers remove and add",
+			current: []routeEntry{
+				{Network: "192.168.1.0/24", Gateway: "10.0.0.1"},
+			},
+			desired: []routeEntry{
+				{Network: "192.168.1.0/24", Gateway: "10.0.0.2"},
+			},
+			wantAddLen:    1,
+			wantRemoveLen: 1,
+		},
+		{
+			name: "mix of add remove and keep",
+			current: []routeEntry{
+				{Network: "10.0.0.0/8", Gateway: "172.16.0.1"},
+				{Network: "stale.net/24", Gateway: "172.16.0.1"},
+			},
+			desired: []routeEntry{
+				{Network: "10.0.0.0/8", Gateway: "172.16.0.1"},
+				{Network: "192.168.0.0/16", Gateway: "172.16.0.1"},
+			},
+			wantAddLen:    1,
+			wantRemoveLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			add, remove := calculateRouteDiff(tt.current, tt.desired)
+			if len(add) != tt.wantAddLen {
+				t.Errorf("toAdd: got %d, want %d", len(add), tt.wantAddLen)
+			}
+			if len(remove) != tt.wantRemoveLen {
+				t.Errorf("toRemove: got %d, want %d", len(remove), tt.wantRemoveLen)
+			}
+		})
+	}
+}
+
+// TestNormalizeNetwork verifies host-route normalization.
+func TestNormalizeNetwork(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"10.0.0.1", "10.0.0.1/32"},
+		{"10.0.0.1/32", "10.0.0.1/32"},
+		{"192.168.0.0/24", "192.168.0.0/24"},
+		{"fd00::1", "fd00::1/128"},
+		{"fd00::1/128", "fd00::1/128"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeNetwork(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeNetwork(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetCurrentRoutes uses a mock executor so no real "ip" binary is required.
+func TestGetCurrentRoutes(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("getCurrentRoutes is Linux-only")
+	}
+
+	ipOutput := strings.Join([]string{
+		"192.168.1.0/24 via 10.0.0.1 dev wg0 proto static",
+		"10.0.0.0/8 via 10.0.0.2 dev wg0 proto static",
+		"",
+	}, "\n")
+
+	mock := &MockCommandExecutor{
+		commandFunc: func(name string, args ...string) Command {
+			if name == "ip" {
+				return &MockCommand{outputFunc: func() ([]byte, error) {
+					return []byte(ipOutput), nil
+				}}
+			}
+			return &MockCommand{}
+		},
+	}
+
+	withMockExecutor(t, mock, func() {
+		routes, err := getCurrentRoutes("wg0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(routes) != 2 {
+			t.Fatalf("expected 2 routes, got %d", len(routes))
+		}
+		if routes[0].Network != "192.168.1.0/24" {
+			t.Errorf("route[0].Network = %q, want 192.168.1.0/24", routes[0].Network)
+		}
+		if routes[0].Gateway != "10.0.0.1" {
+			t.Errorf("route[0].Gateway = %q, want 10.0.0.1", routes[0].Gateway)
+		}
+	})
+}
+
+// TestGetCurrentRoutesSkipsNoGateway verifies that routes without "via" are ignored.
+func TestGetCurrentRoutesSkipsNoGateway(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("getCurrentRoutes is Linux-only")
+	}
+
+	// "local" route lines have no "via" — must be skipped
+	ipOutput := "10.0.0.0/8 dev wg0 proto kernel scope link src 10.0.0.1\n"
+
+	mock := &MockCommandExecutor{
+		commandFunc: func(name string, args ...string) Command {
+			return &MockCommand{outputFunc: func() ([]byte, error) {
+				return []byte(ipOutput), nil
+			}}
+		},
+	}
+
+	withMockExecutor(t, mock, func() {
+		routes, err := getCurrentRoutes("wg0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(routes) != 0 {
+			t.Errorf("expected 0 routes (no via), got %d", len(routes))
+		}
+	})
+}
+
+// TestApplyRouteDiff_AddAndRemove verifies the commands issued during a diff apply.
+func TestApplyRouteDiff_AddAndRemove(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("applyRouteDiff is Linux-only")
+	}
+
+	var cmds []string
+	mock := &MockCommandExecutor{
+		commandFunc: func(name string, args ...string) Command {
+			cmds = append(cmds, name+" "+strings.Join(args, " "))
+			return &MockCommand{}
+		},
+	}
+
+	toAdd := []routeEntry{{Network: "10.0.1.0/24", Gateway: "10.0.0.1"}}
+	toRemove := []routeEntry{{Network: "10.0.2.0/24", Gateway: "10.0.0.1"}}
+
+	withMockExecutor(t, mock, func() {
+		if err := applyRouteDiff("wg0", toAdd, toRemove); err != nil {
+			t.Fatalf("applyRouteDiff failed: %v", err)
+		}
+	})
+
+	found := func(substr string) bool {
+		for _, c := range cmds {
+			if strings.Contains(c, substr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !found("route del 10.0.2.0/24") {
+		t.Errorf("expected 'route del' command, got: %v", cmds)
+	}
+	if !found("route replace 10.0.1.0/24") {
+		t.Errorf("expected 'route replace' command, got: %v", cmds)
+	}
+	if !found("sysctl") {
+		t.Errorf("expected sysctl ip_forward command, got: %v", cmds)
+	}
+}
+
+// TestApplyRouteDiff_AddFailure verifies error propagation when "ip route replace" fails.
+func TestApplyRouteDiff_AddFailure(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("applyRouteDiff is Linux-only")
+	}
+
+	mock := &MockCommandExecutor{
+		commandFunc: func(name string, args ...string) Command {
+			if name == "ip" && len(args) > 0 && args[0] == "route" && args[1] == "replace" {
+				return &MockCommand{
+					combinedOutputFunc: func() ([]byte, error) {
+						return []byte("RTNETLINK answers: Operation not permitted"), fmt.Errorf("exit status 2")
+					},
+				}
+			}
+			return &MockCommand{}
+		},
+	}
+
+	toAdd := []routeEntry{{Network: "10.0.1.0/24", Gateway: "10.0.0.1"}}
+
+	withMockExecutor(t, mock, func() {
+		err := applyRouteDiff("wg0", toAdd, nil)
+		if err == nil {
+			t.Fatal("expected error from failed route replace, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to add route") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}

--- a/pkg/daemon/systemd.go
+++ b/pkg/daemon/systemd.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -52,7 +51,7 @@ type SystemdServiceConfig struct {
 func GenerateSystemdUnit(cfg SystemdServiceConfig) (string, error) {
 	if cfg.BinaryPath == "" {
 		// Find wgmesh binary
-		path, err := exec.LookPath("wgmesh")
+		path, err := cmdExecutor.LookPath("wgmesh")
 		if err != nil {
 			path, err = filepath.Abs(os.Args[0])
 			if err != nil {
@@ -144,17 +143,17 @@ func InstallSystemdService(cfg SystemdServiceConfig) error {
 	}
 
 	// Reload systemd
-	if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
+	if err := cmdExecutor.Command("systemctl", "daemon-reload").Run(); err != nil {
 		return fmt.Errorf("failed to reload systemd: %w", err)
 	}
 
 	// Enable service
-	if err := exec.Command("systemctl", "enable", "wgmesh.service").Run(); err != nil {
+	if err := cmdExecutor.Command("systemctl", "enable", "wgmesh.service").Run(); err != nil {
 		return fmt.Errorf("failed to enable service: %w", err)
 	}
 
 	// Start service
-	if err := exec.Command("systemctl", "start", "wgmesh.service").Run(); err != nil {
+	if err := cmdExecutor.Command("systemctl", "start", "wgmesh.service").Run(); err != nil {
 		return fmt.Errorf("failed to start service: %w", err)
 	}
 
@@ -164,10 +163,10 @@ func InstallSystemdService(cfg SystemdServiceConfig) error {
 // UninstallSystemdService stops and removes the wgmesh systemd service
 func UninstallSystemdService() error {
 	// Stop service
-	exec.Command("systemctl", "stop", "wgmesh.service").Run()
+	cmdExecutor.Command("systemctl", "stop", "wgmesh.service").Run()
 
 	// Disable service
-	exec.Command("systemctl", "disable", "wgmesh.service").Run()
+	cmdExecutor.Command("systemctl", "disable", "wgmesh.service").Run()
 
 	// Remove unit file
 	unitPath := "/etc/systemd/system/wgmesh.service"
@@ -186,14 +185,14 @@ func UninstallSystemdService() error {
 	_ = os.Remove(secretDir)
 
 	// Reload systemd
-	exec.Command("systemctl", "daemon-reload").Run()
+	cmdExecutor.Command("systemctl", "daemon-reload").Run()
 
 	return nil
 }
 
 // ServiceStatus returns the status of the wgmesh systemd service
 func ServiceStatus() (string, error) {
-	cmd := exec.Command("systemctl", "is-active", "wgmesh.service")
+	cmd := cmdExecutor.Command("systemctl", "is-active", "wgmesh.service")
 	output, err := cmd.Output()
 	if err != nil {
 		return "inactive", nil


### PR DESCRIPTION
## Summary

Closes #99.

Replaces all 11 direct `exec.Command` / `exec.LookPath` calls in `routes.go` and `systemd.go` with the existing `cmdExecutor` interface, making every code path testable without root privileges or real system binaries.

### Files changed

| File | Change |
|---|---|
| `pkg/daemon/routes.go` | 6 `exec.Command` → `cmdExecutor.Command`; remove `os/exec` import |
| `pkg/daemon/systemd.go` | 7 `exec.Command` + 1 `exec.LookPath` → `cmdExecutor` equivalents; remove `os/exec` import |
| `pkg/daemon/routes_test.go` | **New** — 6 mock-based tests |
| `pkg/daemon/systemd_test.go` | +3 mock-based tests for `ServiceStatus` and systemctl command sequences |

### Test coverage added

- `TestCalculateRouteDiff` — add/remove/keep/gateway-change logic
- `TestNormalizeNetwork` — IPv4/IPv6 host-route normalization
- `TestGetCurrentRoutes` — `ip route show` output parsing
- `TestGetCurrentRoutesSkipsNoGateway` — routes without `via` are ignored
- `TestApplyRouteDiff_AddAndRemove` — verifies `del`, `replace`, and `sysctl` commands issued
- `TestApplyRouteDiff_AddFailure` — error propagated from failed `ip route replace`
- `TestServiceStatus_Active` — trimmed output returned
- `TestServiceStatus_Inactive` — `"inactive"` returned on error
- `TestInstallSystemdService_ExecCommands` — `daemon-reload`, `enable`, `start` issued
- `TestUninstallSystemdService_ExecCommands` — `stop`, `disable`, `daemon-reload` issued

All tests pass under `go test -race ./...`. Zero behavior change — pure testability refactor.