### PR TITLE
feat: cache wg and wireguard-go binary paths at package init (fixes #111)

### DIFF
--- a/pkg/wireguard/keys.go
+++ b/pkg/wireguard/keys.go
@@ -8,7 +8,7 @@ import (
 )
 
 func GenerateKeyPair() (privateKey, publicKey string, err error) {
-	privCmd := exec.Command("wg", "genkey")
+	privCmd := exec.Command(wgPath, "genkey")
 	var privOut bytes.Buffer
 	privCmd.Stdout = &privOut
 
@@ -18,7 +18,7 @@ func GenerateKeyPair() (privateKey, publicKey string, err error) {
 
 	privateKey = strings.TrimSpace(privOut.String())
 
-	pubCmd := exec.Command("wg", "pubkey")
+	pubCmd := exec.Command(wgPath, "pubkey")
 	pubCmd.Stdin = strings.NewReader(privateKey)
 	var pubOut bytes.Buffer
 	pubCmd.Stdout = &pubOut


### PR DESCRIPTION
## Summary

Eliminates per-call PATH lookups for the `wg` and `wireguard-go` binaries in the reconcile loop (every 5 seconds, multiple calls per cycle) by resolving paths once at package init.

Closes #111.

## Changes

### `pkg/wireguard/apply.go`
- Added `wgPath` package var + `init()` that calls `exec.LookPath("wg")` once
- All `exec.Command("wg", ...)` calls replaced with `exec.Command(wgPath, ...)`

### `pkg/wireguard/keys.go`
- Uses the same `wgPath` var (same package, initialized once)

### `pkg/daemon/helpers.go`
- Added `wgBinPath` and `wireguardGoBinPath` package vars + `init()` that resolves both
- All `cmdExecutor.Command("wg", ...)` calls use `wgBinPath`
- `wireguard-go` invocation uses `wireguardGoBinPath`
- Falls back to bare binary name if `LookPath` fails (identical runtime behaviour)

## Known issue

`TestCreateInterface_Darwin` needs a follow-up fix (tracked in #171) to update mock `commandFunc` to match on the cached absolute path. Goose is assigned to #171.

## Testing

`go test ./...` passes on Linux. macOS `TestCreateInterface_Darwin` requires the fix in #171.