### PR TITLE
fix: auto-update stale PR branches before merge attempt

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ name: Auto-merge on CI pass
 on:
   # Fires when CI workflows complete on PRs
   workflow_run:
-    workflows: ["Build and Push Docker Images"]
+    workflows: ["Build and Push Docker Images", "CodeQL"]
     types: [completed]
   # Also fires when a draft PR is marked ready for review
   pull_request:


### PR DESCRIPTION
## Summary

- Auto-merge now calls `pulls.updateBranch()` on PRs that are behind main before attempting to merge
- If the branch update succeeds, CI re-runs and the next 10-minute cycle merges the PR
- If the update fails (true conflict requiring manual resolution), a `conflict` label is added
- `conflict` label is auto-removed once the branch is clean again

## Problem

All 9 open PRs have merge conflicts after the recent batch merge of PRs #158-#173. The auto-merge workflow detects checks pass but fails with "Pull Request is not mergeable" because the branches are stale.

## Additional fixes

- `workflow_dispatch` now checks all open PRs (previously only `schedule` did)
- Extracted `owner`/`repo` variables to reduce repetition
- Added comment explaining sequential processing rationale