### PR TITLE
refactor: wrap bare error returns in exchange and registry (fixes #114)

### DIFF
--- a/pkg/discovery/exchange.go
+++ b/pkg/discovery/exchange.go
@@ -417,7 +417,10 @@ func (pe *PeerExchange) sendReply(remoteAddr *net.UDPAddr) error {
 	}
 
 	_, err = pe.conn.WriteToUDP(data, remoteAddr)
-	return fmt.Errorf("failed to send reply: %w", err)
+	if err != nil {
+		return fmt.Errorf("failed to send reply: %w", err)
+	}
+	return nil
 }
 
 // ExchangeWithPeer initiates a peer exchange with a remote address
@@ -1057,7 +1060,10 @@ func (pe *PeerExchange) SendAnnounce(remoteAddr *net.UDPAddr) error {
 	}
 
 	_, err = pe.conn.WriteToUDP(data, remoteAddr)
-	return fmt.Errorf("failed to send announce: %w", err)
+	if err != nil {
+		return fmt.Errorf("failed to send announce: %w", err)
+	}
+	return nil
 }
 
 // SendGoodbye sends a shutdown notification to a specific peer exchange endpoint.


### PR DESCRIPTION
## Summary
- Wraps bare `return err` with `fmt.Errorf` context in `pkg/discovery/exchange.go` (`sendReply`, `SendAnnounce`)
- Properly guards wrapping with `if err != nil` to avoid returning non-nil errors on success paths
- Fixes inconsistent error wrapping identified in issue #114

Note: `registry.go` error wrapping was already applied to main via prior merges.

Authored by Goose, rebased and bug-fixed by nycterent.