### PR TITLE
fix: spec-auto-approve triggers on ready_for_review and edited events

### DIFF
--- a/.github/workflows/spec-auto-approve.yml
+++ b/.github/workflows/spec-auto-approve.yml
@@ -13,7 +13,7 @@ name: Spec Auto-Approve
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, ready_for_review, edited]
     branches: [main]
 
 permissions:


### PR DESCRIPTION
## Summary

Copilot opens spec PRs as draft with `[WIP]` title, then renames to `spec: Issue #N ...` and marks ready for review. The `spec-auto-approve.yml` workflow only triggered on `opened`, so it ran with the old title and skipped validation (the `if: contains(title, 'spec:')` check failed).

This caused PR #177 (spec for issue #176) to never get auto-approved, which meant Goose never started implementation — the entire pipeline stalled.

### Fix

Add `ready_for_review` and `edited` event types so the workflow re-fires when:
- Copilot renames the PR title to include `spec:`
- The PR is marked ready for review (undrafted)

Fixes the pipeline stall for issue #176 and prevents future occurrences.