### PR TITLE
fix: trigger Goose via workflow_dispatch instead of labeled event

### DIFF
--- a/.github/workflows/approve-build.yml
+++ b/.github/workflows/approve-build.yml
@@ -40,7 +40,7 @@ jobs:
             const issueMatch = pr.title.match(/Issue #(\d+)/);
             const issueNumber = issueMatch ? parseInt(issueMatch[1], 10) : null;
 
-            // Add the approved-for-build label (triggers goose-build.yml)
+            // Add the approved-for-build label for tracking
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -76,7 +76,24 @@ jobs:
               });
             }
 
-            console.log(`Spec PR #${prNumber} approved by @${reviewer}, labeled for Goose build`);
+            // Directly trigger Goose implementation via workflow_dispatch.
+            // Labels added by workflows don't fire pull_request events (GitHub limitation),
+            // so we invoke goose-build.yml explicitly.
+            if (issueNumber) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'goose-build.yml',
+                ref: 'main',
+                inputs: {
+                  issue_number: String(issueNumber),
+                  spec_pr_number: String(prNumber),
+                },
+              });
+              console.log(`Triggered Goose implementation for issue #${issueNumber}`);
+            }
+
+            console.log(`Spec PR #${prNumber} approved by @${reviewer}, Goose triggered`);
 
   # ──────────────────────────────────────────────────────
   # Non-spec PR: Issue creator approval → auto-merge

--- a/.github/workflows/spec-auto-approve.yml
+++ b/.github/workflows/spec-auto-approve.yml
@@ -134,10 +134,18 @@ jobs:
           
           Goose will now implement the code based on this specification."
           
-          # Add the label that triggers Goose
+          # Add the label for tracking
           gh pr edit $PR_NUM --add-label approved-for-build
           
-          echo "Added approved-for-build label, Goose will start implementation"
+          # Directly trigger Goose implementation via workflow_dispatch.
+          # Labels added by workflows don't fire pull_request events (GitHub limitation),
+          # so we invoke goose-build.yml explicitly instead of relying on the labeled trigger.
+          echo "Triggering Goose implementation for issue #${ISSUE_NUM} (spec PR #${PR_NUM})"
+          gh workflow run goose-build.yml \
+            -f issue_number="${ISSUE_NUM}" \
+            -f spec_pr_number="${PR_NUM}"
+          
+          echo "Goose implementation triggered"
 
       - name: Comment on validation failure
         if: steps.validate.outputs.valid == 'false'


### PR DESCRIPTION
## Summary

Labels added by workflows don't fire `pull_request` events — this is a known GitHub limitation. Both `spec-auto-approve.yml` and `approve-build.yml` were adding the `approved-for-build` label expecting `goose-build.yml` to trigger via `pull_request: [labeled]`, but the event never fired.

This caused Goose to never start implementation after spec approval, breaking the entire automated pipeline.

### Fix

Both workflows now directly invoke `goose-build.yml` via `workflow_dispatch` after approving the spec PR:
- `spec-auto-approve.yml`: uses `gh workflow run` (shell step)
- `approve-build.yml`: uses `actions.createWorkflowDispatch` (JS API)

The `approved-for-build` label is still added for tracking/visibility.

### Pipeline flow (after fix)

```
Issue → needs-triage → Copilot writes spec PR
  → spec-auto-approve validates → approves PR → triggers goose-build.yml directly
    → Goose implements → creates impl PR → auto-merge
```