### PR TITLE
fix: prevent self-referential auth false positive in Goose run

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -463,17 +463,26 @@ jobs:
             echo "Goose finished with exit code: $GOOSE_EXIT"
 
             # ── Check for non-recoverable errors (fail immediately) ──
-            # Use narrow patterns to avoid false positives from code/docs
-            # that Goose reads or writes containing words like "authentication"
-            if grep -qiE "401 unauthorized|authentication failed|invalid.?api.?key|api key is invalid" /tmp/goose-output.log; then
+            # IMPORTANT: Goose reads and writes workflow YAML files, so its
+            # output will contain any grep patterns we define here as literal
+            # text. To avoid self-referential false positives, we filter out
+            # lines that look like source code (containing grep, if, echo,
+            # comments, or indented code) before checking for real errors.
+            AUTH_ERRORS=$(grep -iE "401 unauthorized|authentication failed|invalid.{0,3}api.{0,3}key|api key is invalid" /tmp/goose-output.log \
+              | grep -ivE '^\s*(#|if |grep |echo |//|--|\*|.*\bgrep\b|.*\.yml|.*\.yaml|.*\.sh)' \
+              || true)
+            if [ -n "$AUTH_ERRORS" ]; then
               echo "::error::Goose encountered authentication errors (non-recoverable)"
-              tail -30 /tmp/goose-output.log
+              echo "$AUTH_ERRORS" | tail -5
               exit 1
             fi
 
-            if grep -qi "unexpected argument" /tmp/goose-output.log; then
+            CLI_ERRORS=$(grep -i "unexpected argument" /tmp/goose-output.log \
+              | grep -ivE '^\s*(#|if |grep |echo |//|--|\*)' \
+              || true)
+            if [ -n "$CLI_ERRORS" ]; then
               echo "::error::Goose CLI argument error (non-recoverable)"
-              tail -30 /tmp/goose-output.log
+              echo "$CLI_ERRORS" | tail -5
               exit 1
             fi
 


### PR DESCRIPTION
## Problem

Goose run for issue #189 (run 22155988788) succeeded — exit code 0, implementation complete — but was killed by our own auth error detection:

```
Goose finished with exit code: 0
##[error]Goose encountered authentication errors (non-recoverable)
```

**Root cause:** Goose reads and modifies `goose-build.yml` during implementation (issue #189 is about modifying this exact file). Its output contains our grep patterns as literal text, so `grep -qiE "authentication failed"` matched the pattern definition itself.

## Fix

Filter out lines that look like source code before checking for real errors:
- Lines starting with `#`, `if`, `grep`, `echo`, `//`, `--`, `*`
- Lines containing `.yml`, `.yaml`, `.sh`, or `grep`

This ensures only actual HTTP/API authentication errors trigger the non-recoverable exit.

## Verification

The mem0 steps all succeeded in the failed run — this is purely about the false positive in error detection.

Closes no issue — pipeline infrastructure fix.