### PR TITLE
fix: strip source code lines before checking Goose auth errors

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -463,26 +463,22 @@ jobs:
             echo "Goose finished with exit code: $GOOSE_EXIT"
 
             # ── Check for non-recoverable errors (fail immediately) ──
-            # IMPORTANT: Goose reads and writes workflow YAML files, so its
-            # output will contain any grep patterns we define here as literal
-            # text. To avoid self-referential false positives, we filter out
-            # lines that look like source code (containing grep, if, echo,
-            # comments, or indented code) before checking for real errors.
-            AUTH_ERRORS=$(grep -iE "401 unauthorized|authentication failed|invalid.{0,3}api.{0,3}key|api key is invalid" /tmp/goose-output.log \
-              | grep -ivE '^\s*(#|if |grep |echo |//|--|\*|.*\bgrep\b|.*\.yml|.*\.yaml|.*\.sh)' \
-              || true)
-            if [ -n "$AUTH_ERRORS" ]; then
+            # IMPORTANT: Goose reads and writes workflow files, so its output
+            # contains our grep patterns as literal text (with line numbers
+            # like "480: grep -i ..."). We strip ALL lines that contain
+            # "grep" or look like source code to avoid self-referential
+            # false positives.
+            CLEAN_LOG=$(grep -vE 'grep|\.yml|\.yaml|\.sh|^\s*#|^\s*//|^\d+:' /tmp/goose-output.log || true)
+
+            if echo "$CLEAN_LOG" | grep -qiE "401 unauthorized|authentication failed|invalid.{0,3}api.{0,3}key|api key is invalid"; then
               echo "::error::Goose encountered authentication errors (non-recoverable)"
-              echo "$AUTH_ERRORS" | tail -5
+              echo "$CLEAN_LOG" | grep -iE "401|authentication|api.key" | tail -5
               exit 1
             fi
 
-            CLI_ERRORS=$(grep -i "unexpected argument" /tmp/goose-output.log \
-              | grep -ivE '^\s*(#|if |grep |echo |//|--|\*)' \
-              || true)
-            if [ -n "$CLI_ERRORS" ]; then
+            if echo "$CLEAN_LOG" | grep -qi "unexpected argument"; then
               echo "::error::Goose CLI argument error (non-recoverable)"
-              echo "$CLI_ERRORS" | tail -5
+              echo "$CLEAN_LOG" | grep -i "unexpected argument" | tail -5
               exit 1
             fi
 


### PR DESCRIPTION
## Problem

PR #193 fixed self-referential false positives where Goose's output contained our grep patterns. But Goose outputs file contents with **line number prefixes** (e.g., `480: grep -i "unexpected argument"`), which bypassed the `^\s*(#|if |grep...)` filter.

Run 22156332467: Goose succeeded (exit 0) but was killed by `"unexpected argument"` pattern matching its own grep command in the output.

## Fix

New approach — pre-filter the entire log to create a `CLEAN_LOG`:
- Remove ALL lines containing `grep`, `.yml`, `.yaml`, `.sh`
- Remove comment lines (`#`, `//`)  
- Remove lines starting with digits + colon (line number prefixes like `480:`)

Then check `CLEAN_LOG` for real errors. This is robust against any source code echo pattern.

## Context

This is the third Goose run for issue #189 (mem0 encryption). The mem0 memory system works correctly — retrieve and save steps all pass. Only the error detection is killing successful runs.