### PR TITLE
fix: use WGMESH_RUN_ID to isolate parallel tier VMs

### DIFF
--- a/.github/workflows/hetzner-integration.yml
+++ b/.github/workflows/hetzner-integration.yml
@@ -132,7 +132,7 @@ jobs:
             --tiers "${{ matrix.tier }}"
         env:
           SSH_KEY_FILE: ${{ env.SSH_KEY_FILE }}
-          GITHUB_RUN_ID: "${{ github.run_id }}-t${{ matrix.tier }}"
+          WGMESH_RUN_ID: "${{ github.run_id }}-t${{ matrix.tier }}"
           VM_PREFIX: "wgmesh-t${{ matrix.tier }}"
 
       - name: Upload test logs
@@ -153,7 +153,7 @@ jobs:
           teardown_orphans || true
         env:
           SSH_KEY_FILE: ${{ env.SSH_KEY_FILE }}
-          GITHUB_RUN_ID: "${{ github.run_id }}-t${{ matrix.tier }}"
+          WGMESH_RUN_ID: "${{ github.run_id }}-t${{ matrix.tier }}"
           VM_PREFIX: "wgmesh-t${{ matrix.tier }}"
 
   # -----------------------------------------------------------------------

--- a/testlab/cloud/provision.sh
+++ b/testlab/cloud/provision.sh
@@ -47,7 +47,7 @@ provision_vms() {
     local count="${1:-5}"
     local locations=("hel1" "nbg1" "fsn1")
     local key_name="${VM_PREFIX}-key"
-    local run_id="${GITHUB_RUN_ID:-$(date +%s)}"
+    local run_id="${WGMESH_RUN_ID:-${GITHUB_RUN_ID:-$(date +%s)}}"
 
     local letters=(a b c d e f g h)
 
@@ -121,7 +121,7 @@ provision_vms() {
 # NOTE: NODE_MESH_IPS is NOT populated here — mesh IPs are derived dynamically
 # by the daemon. Call populate_mesh_ips after starting the mesh.
 populate_node_info() {
-    local run_id="${GITHUB_RUN_ID:-}"
+    local run_id="${WGMESH_RUN_ID:-${GITHUB_RUN_ID:-}}"
 
     # Get server names
     local server_names
@@ -353,7 +353,7 @@ stop_mesh() {
 
 # Delete ALL VMs and SSH key for this run.
 teardown_vms() {
-    local run_id="${GITHUB_RUN_ID:-}"
+    local run_id="${WGMESH_RUN_ID:-${GITHUB_RUN_ID:-}}"
 
     log_info "Tearing down VMs..."
 


### PR DESCRIPTION
## Problem

Parallel integration tier jobs (from #197) all shared the same Hetzner VM label `run=<GITHUB_RUN_ID>` because `GITHUB_RUN_ID` is a **reserved** GitHub Actions variable that cannot be overridden via step `env:`.

This caused:
1. `populate_node_info` in Tier 1 discovered all 9 VMs (from Tiers 1+2+3)
2. Tier 1 tried to SSH into Tier 2/3 VMs using Tier 1's SSH key → **Permission denied**
3. `teardown_vms` in any tier's EXIT trap would delete ALL tiers' VMs

## Fix

- Use custom `WGMESH_RUN_ID` env var in the workflow (`<run_id>-t<N>`)
- `provision.sh` prefers `WGMESH_RUN_ID`, falls back to `GITHUB_RUN_ID`
- Each tier now gets a unique label: `run=22158790994-t1`, `run=22158790994-t2`, etc.