### PR TITLE
fix: increase tier timeout to 120 min for parallel load

### DIFF
--- a/.github/workflows/hetzner-integration.yml
+++ b/.github/workflows/hetzner-integration.yml
@@ -78,16 +78,17 @@ jobs:
   #   Tier 4 (Partitions):      ~15 min
   #   Tier 5 (NAT Simulation):   ~1 min  (all SKIP — not yet implemented)
   #   Tier 6 (Chaos Monkey):    ~35 min
-  #   Tier 7 (Stability Soak):  ~35 min  (5+10+15 min soaks)
+  #   Tier 7 (Stability Soak):  ~37 min  (5+10+15 min soaks)
   #
-  # 90 min gives generous buffer for the heaviest tiers (3, 6, 7)
-  # plus ~3 min provisioning overhead per tier.
+  # When all 7 tiers run in parallel (35 VMs), shared Hetzner infra
+  # adds ~30% overhead. Tier 3 solo takes ~69 min but can reach ~90 min
+  # under parallel load. 120 min gives safe buffer.
   # -----------------------------------------------------------------------
   tier:
     name: "Tier ${{ matrix.tier }}"
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

Tier 3 (Network Chaos, 9 tests) timed out at 90 min during the full 7-tier parallel run (35 VMs). Solo it completes in ~69 min, but shared Hetzner infra under parallel load adds ~30% overhead.

## Fix

Increase `timeout-minutes` from 90 to 120.

## Evidence

- Run 22167072186: Tiers 1,2,4,5,6,7 all PASS, Tier 3 cancelled at 90 min
- Solo Tier 3 run (22159561593): 4131s = 69 min with 3 VMs
- Estimated parallel overhead: ~30% → 69 * 1.3 = ~90 min (right at limit)
- 120 min gives comfortable buffer