### PR TITLE
feat: data plane validation + test observability (Gantt, tracing, pprof)

### DIFF
--- a/.github/workflows/hetzner-integration.yml
+++ b/.github/workflows/hetzner-integration.yml
@@ -135,6 +135,16 @@ jobs:
           SSH_KEY_FILE: ${{ env.SSH_KEY_FILE }}
           WGMESH_RUN_ID: "${{ github.run_id }}-t${{ matrix.tier }}"
           VM_PREFIX: "wgmesh-t${{ matrix.tier }}"
+          WGMESH_PPROF: "1"
+
+      - name: Generate test report
+        if: always()
+        run: |
+          if [ -f /tmp/wgmesh-ci-logs/trace.jsonl ]; then
+            python3 testlab/cloud/gen-report.py \
+              /tmp/wgmesh-ci-logs/trace.jsonl \
+              /tmp/wgmesh-ci-logs/report.html || true
+          fi
 
       - name: Tier summary
         if: always()

--- a/testlab/cloud/chaos.sh
+++ b/testlab/cloud/chaos.sh
@@ -51,6 +51,7 @@ _get_iface() {
 #   corrupt <percent>                  — bit-level corruption
 chaos_apply() {
     local node="$1" type="$2"; shift 2
+    emit_event "chaos_apply" "$node" "type=$type" "params=$*"
     local iface
     iface=$(_get_iface "$node")
 
@@ -104,6 +105,7 @@ chaos_apply() {
 # Remove all tc netem impairments from a node.
 chaos_clear() {
     local node="$1"
+    emit_event "chaos_clear" "$node"
     local iface
     iface=$(_get_iface "$node")
     run_on_ok "$node" "tc qdisc del dev $iface root 2>/dev/null"

--- a/testlab/cloud/gen-report.py
+++ b/testlab/cloud/gen-report.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Generate an HTML test report from NDJSON trace events.
+
+Usage:
+    python3 gen-report.py <trace.jsonl> <output.html>
+
+Reads trace events emitted by lib.sh's emit_event() function and generates
+a self-contained HTML report with:
+  - Test execution timeline (Gantt-style bars)
+  - Chaos event overlay
+  - Data plane metrics (transfer, iperf, MTU results)
+  - Duration breakdown per test
+  - Tier summary statistics
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def load_events(path: str) -> list[dict]:
+    """Load NDJSON events from trace file."""
+    events = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return events
+
+
+def build_test_timeline(events: list[dict]) -> list[dict]:
+    """Pair test_start/test_end events into timeline entries."""
+    starts = {}
+    timeline = []
+    for ev in events:
+        if ev["type"] == "test_start":
+            starts[ev["name"]] = ev
+        elif ev["type"] == "test_end":
+            start_ev = starts.pop(ev["name"], None)
+            start_ts = start_ev["ts"] if start_ev else ev["ts"]
+            timeline.append({
+                "id": ev["name"],
+                "test_name": ev.get("name", ""),
+                "tier": ev.get("tier", "?"),
+                "start": start_ts,
+                "end": ev["ts"],
+                "duration": float(ev.get("duration", ev["ts"] - start_ts)),
+                "result": ev.get("result", "?"),
+            })
+    return timeline
+
+
+def build_chaos_events(events: list[dict]) -> list[dict]:
+    """Extract chaos apply/clear events."""
+    chaos = []
+    for ev in events:
+        if ev["type"] in ("chaos_apply", "chaos_clear"):
+            chaos.append({
+                "ts": ev["ts"],
+                "type": ev["type"],
+                "node": ev["name"],
+                "chaos_type": ev.get("type_param", ev.get("type", "")),
+                "params": ev.get("params", ""),
+                "tier": ev.get("tier", "?"),
+            })
+    return chaos
+
+
+def build_data_plane_metrics(events: list[dict]) -> list[dict]:
+    """Extract data plane verification results."""
+    metrics = []
+    for ev in events:
+        if ev["type"].startswith("data_"):
+            metrics.append({
+                "ts": ev["ts"],
+                "type": ev["type"],
+                "name": ev["name"],
+                "tier": ev.get("tier", "?"),
+                **{k: v for k, v in ev.items()
+                   if k not in ("ts", "type", "name", "tier")},
+            })
+    return metrics
+
+
+def build_tier_summary(events: list[dict]) -> list[dict]:
+    """Extract tier start/end timing."""
+    starts = {}
+    tiers = []
+    for ev in events:
+        if ev["type"] == "tier_start":
+            starts[ev["name"]] = ev
+        elif ev["type"] == "tier_end":
+            start_ev = starts.pop(ev["name"], None)
+            start_ts = start_ev["ts"] if start_ev else ev["ts"]
+            tiers.append({
+                "name": ev["name"],
+                "start": start_ts,
+                "end": ev["ts"],
+                "duration": ev["ts"] - start_ts,
+                "tests": start_ev.get("tests", "?") if start_ev else "?",
+            })
+    return tiers
+
+
+def format_duration(seconds: float) -> str:
+    """Format seconds as human-readable string."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    m, s = divmod(int(seconds), 60)
+    if m < 60:
+        return f"{m}m{s:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h{m:02d}m{s:02d}s"
+
+
+def generate_html(events: list[dict]) -> str:
+    """Generate self-contained HTML report."""
+    timeline = build_test_timeline(events)
+    chaos = build_chaos_events(events)
+    data_metrics = build_data_plane_metrics(events)
+    tiers = build_tier_summary(events)
+
+    if not timeline:
+        return "<html><body><h1>No test events found</h1></body></html>"
+
+    # Calculate global time range
+    all_times = [t["start"] for t in timeline] + [t["end"] for t in timeline]
+    t_min = min(all_times)
+    t_max = max(all_times)
+    t_range = max(t_max - t_min, 1)
+
+    # Color map
+    colors = {"PASS": "#22c55e", "FAIL": "#ef4444", "SKIP": "#eab308"}
+
+    # Build Gantt bars
+    gantt_bars = []
+    for t in timeline:
+        left_pct = ((t["start"] - t_min) / t_range) * 100
+        width_pct = max(((t["end"] - t["start"]) / t_range) * 100, 0.5)
+        color = colors.get(t["result"], "#6b7280")
+        gantt_bars.append(f"""
+        <div class="gantt-row">
+            <div class="gantt-label">{t['id']}</div>
+            <div class="gantt-track">
+                <div class="gantt-bar" style="left:{left_pct:.2f}%;width:{width_pct:.2f}%;background:{color}"
+                     title="{t['id']}: {format_duration(t['duration'])} ({t['result']})">
+                    {format_duration(t['duration'])}
+                </div>
+            </div>
+        </div>""")
+
+    # Build test results table
+    test_rows = []
+    for t in timeline:
+        badge = f'<span class="badge" style="background:{colors.get(t["result"], "#6b7280")}">{t["result"]}</span>'
+        test_rows.append(f"""
+        <tr>
+            <td>{t['id']}</td>
+            <td>Tier {t['tier']}</td>
+            <td>{badge}</td>
+            <td>{format_duration(t['duration'])}</td>
+        </tr>""")
+
+    # Build data plane table
+    dp_rows = []
+    for m in data_metrics:
+        dp_rows.append(f"""
+        <tr>
+            <td>{m['type']}</td>
+            <td>{m['name']}</td>
+            <td>Tier {m['tier']}</td>
+            <td>{m.get('result', m.get('mbps', '-'))}</td>
+            <td>{m.get('size_mb', m.get('payload', m.get('duration', '-')))}</td>
+        </tr>""")
+
+    # Build tier summary
+    tier_rows = []
+    for t in tiers:
+        tier_rows.append(f"""
+        <tr>
+            <td>{t['name']}</td>
+            <td>{t['tests']}</td>
+            <td>{format_duration(t['duration'])}</td>
+        </tr>""")
+
+    # Chaos events log
+    chaos_rows = []
+    for c in chaos:
+        rel_time = format_duration(c["ts"] - t_min)
+        chaos_rows.append(f"""
+        <tr>
+            <td>{rel_time}</td>
+            <td>Tier {c['tier']}</td>
+            <td>{c['type']}</td>
+            <td>{c['node']}</td>
+            <td>{c.get('params', '')}</td>
+        </tr>""")
+
+    # Stats
+    total = len(timeline)
+    passed = sum(1 for t in timeline if t["result"] == "PASS")
+    failed = sum(1 for t in timeline if t["result"] == "FAIL")
+    skipped = sum(1 for t in timeline if t["result"] == "SKIP")
+    total_duration = format_duration(t_range)
+
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>wgmesh Integration Test Report</title>
+<style>
+    * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+    body {{ font-family: -apple-system, system-ui, sans-serif; background: #0f172a; color: #e2e8f0; padding: 2rem; }}
+    h1 {{ color: #f1f5f9; margin-bottom: 0.5rem; }}
+    h2 {{ color: #94a3b8; margin: 2rem 0 1rem; border-bottom: 1px solid #334155; padding-bottom: 0.5rem; }}
+    .stats {{ display: flex; gap: 1.5rem; margin: 1rem 0 2rem; flex-wrap: wrap; }}
+    .stat {{ background: #1e293b; padding: 1rem 1.5rem; border-radius: 8px; min-width: 120px; }}
+    .stat-value {{ font-size: 2rem; font-weight: 700; }}
+    .stat-label {{ color: #94a3b8; font-size: 0.85rem; }}
+    .pass {{ color: #22c55e; }}
+    .fail {{ color: #ef4444; }}
+    .skip {{ color: #eab308; }}
+    table {{ width: 100%; border-collapse: collapse; background: #1e293b; border-radius: 8px; overflow: hidden; margin-bottom: 1rem; }}
+    th {{ background: #334155; padding: 0.75rem 1rem; text-align: left; font-size: 0.85rem; color: #94a3b8; }}
+    td {{ padding: 0.5rem 1rem; border-top: 1px solid #334155; font-size: 0.9rem; }}
+    tr:hover {{ background: #334155; }}
+    .badge {{ padding: 2px 8px; border-radius: 4px; color: white; font-size: 0.8rem; font-weight: 600; }}
+    .gantt-row {{ display: flex; align-items: center; margin: 2px 0; }}
+    .gantt-label {{ width: 80px; font-size: 0.8rem; color: #94a3b8; text-align: right; padding-right: 8px; flex-shrink: 0; }}
+    .gantt-track {{ flex: 1; height: 24px; background: #1e293b; border-radius: 4px; position: relative; overflow: hidden; }}
+    .gantt-bar {{ position: absolute; height: 100%; border-radius: 4px; display: flex; align-items: center; padding: 0 6px;
+                  font-size: 0.7rem; color: white; white-space: nowrap; overflow: hidden; min-width: 4px; }}
+    .footer {{ margin-top: 3rem; color: #475569; font-size: 0.8rem; text-align: center; }}
+    .section {{ margin-bottom: 2rem; }}
+    .empty {{ color: #64748b; font-style: italic; padding: 1rem; }}
+</style>
+</head>
+<body>
+<h1>wgmesh Integration Test Report</h1>
+<p style="color:#64748b">Generated: {generated}</p>
+
+<div class="stats">
+    <div class="stat"><div class="stat-value">{total}</div><div class="stat-label">Total Tests</div></div>
+    <div class="stat"><div class="stat-value pass">{passed}</div><div class="stat-label">Passed</div></div>
+    <div class="stat"><div class="stat-value fail">{failed}</div><div class="stat-label">Failed</div></div>
+    <div class="stat"><div class="stat-value skip">{skipped}</div><div class="stat-label">Skipped</div></div>
+    <div class="stat"><div class="stat-value">{total_duration}</div><div class="stat-label">Duration</div></div>
+</div>
+
+<div class="section">
+<h2>Test Timeline</h2>
+{''.join(gantt_bars) if gantt_bars else '<p class="empty">No timing data</p>'}
+</div>
+
+<div class="section">
+<h2>Tier Summary</h2>
+{'<table><tr><th>Tier</th><th>Tests</th><th>Duration</th></tr>' + ''.join(tier_rows) + '</table>' if tier_rows else '<p class="empty">No tier data</p>'}
+</div>
+
+<div class="section">
+<h2>Test Results</h2>
+<table>
+<tr><th>ID</th><th>Tier</th><th>Result</th><th>Duration</th></tr>
+{''.join(test_rows)}
+</table>
+</div>
+
+<div class="section">
+<h2>Data Plane Metrics</h2>
+{'<table><tr><th>Type</th><th>Pair</th><th>Tier</th><th>Result</th><th>Detail</th></tr>' + ''.join(dp_rows) + '</table>' if dp_rows else '<p class="empty">No data plane events</p>'}
+</div>
+
+<div class="section">
+<h2>Chaos Events ({len(chaos)})</h2>
+{'<table><tr><th>Time</th><th>Tier</th><th>Action</th><th>Node</th><th>Params</th></tr>' + ''.join(chaos_rows) + '</table>' if chaos_rows else '<p class="empty">No chaos events</p>'}
+</div>
+
+<div class="footer">
+    wgmesh integration test observability &middot; {len(events)} trace events
+</div>
+</body>
+</html>"""
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <trace.jsonl> <output.html>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    trace_path = sys.argv[1]
+    output_path = sys.argv[2]
+
+    if not Path(trace_path).exists():
+        print(f"Trace file not found: {trace_path}", file=sys.stderr)
+        sys.exit(1)
+
+    events = load_events(trace_path)
+    if not events:
+        print("Warning: no events found in trace file", file=sys.stderr)
+
+    html = generate_html(events)
+    Path(output_path).write_text(html)
+    print(f"Report generated: {output_path} ({len(events)} events)")
+
+
+if __name__ == "__main__":
+    main()

--- a/testlab/cloud/provision.sh
+++ b/testlab/cloud/provision.sh
@@ -278,6 +278,7 @@ _setup_single_vm() {
     # Create systemd unit
     local extra_flags=""
     [ "$role" = "introducer" ] && extra_flags="--introducer"
+    [ "${WGMESH_PPROF:-0}" = "1" ] && extra_flags="${extra_flags} --pprof localhost:6060"
 
     run_on "$node" "cat > /etc/systemd/system/wgmesh.service << 'UNIT'
 [Unit]
@@ -310,6 +311,7 @@ UNIT
 
 start_mesh() {
     local settle="${1:-30}"
+    emit_event "mesh_start" "start_mesh" "settle=$settle"
 
     # Start introducer first
     for node in "${!NODE_ROLES[@]}"; do
@@ -332,10 +334,12 @@ start_mesh() {
 
     # Discover actual mesh IPs from running WG interfaces
     populate_mesh_ips
+    emit_event "mesh_started" "start_mesh" "nodes=${#NODE_IPS[@]}"
 }
 
 # Stop mesh on all nodes.
 stop_mesh() {
+    emit_event "mesh_stop" "stop_mesh"
     for node in "${!NODE_IPS[@]}"; do
         stop_mesh_node "$node" &
     done
@@ -345,6 +349,7 @@ stop_mesh() {
         run_on_ok "$node" "ip link del $WG_INTERFACE 2>/dev/null"
     done
     log_info "Mesh stopped on all nodes"
+    emit_event "mesh_stopped" "stop_mesh"
 }
 
 # ---------------------------------------------------------------------------

--- a/testlab/cloud/test-cloud.sh
+++ b/testlab/cloud/test-cloud.sh
@@ -401,12 +401,14 @@ _pick_two_nodes() {
 
 # Ensure mesh is clean before each chaos test
 _chaos_setup() {
+    emit_event "chaos_setup_start" "_chaos_setup"
     chaos_clear_all 2>/dev/null || true
     stop_mesh 2>/dev/null || true
     sleep 2
     start_mesh 30
     verify_full_mesh 60
     verify_data_plane_quick   # 1MB TCP transfer on 1 random pair
+    emit_event "chaos_setup_end" "_chaos_setup"
 }
 
 # --- T11: 10% packet loss on 2 nodes ---
@@ -1146,26 +1148,35 @@ log_bold "  Nodes: ${#NODE_IPS[@]}  |  Tiers: $TIERS"
 log_bold "============================================"
 
 if should_run_tier 1; then
+    CURRENT_TIER=1
     TOTAL_TESTS_IN_TIER=4
     log_bold "\n=========================================="
     log_bold "  TIER 1: Topology Formation ($TOTAL_TESTS_IN_TIER tests)"
     log_bold "=========================================="
     tier_start=$(date +%s)
+    TIER_START_EPOCH[1]=$tier_start
+    emit_event "tier_start" "tier_1" "tests=$TOTAL_TESTS_IN_TIER"
     run_test T1  "Basic mesh (3 nodes)"         test_t1_basic_mesh
     run_test T2  "Full mesh (${#NODE_IPS[@]} nodes)" test_t2_full_mesh
     run_test T3  "IPv6 mesh connectivity"        test_t3_ipv6
     run_test T4  "Cross-DC latency sanity"       test_t4_cross_dc_latency
     log_info "Tier 1 data plane gate..."
     verify_data_plane
-    log_bold "  Tier 1 complete in $(( $(date +%s) - tier_start ))s"
+    collect_all_pprof  # baseline profiles after first mesh formation
+    TIER_END_EPOCH[1]=$(date +%s)
+    emit_event "tier_end" "tier_1"
+    log_bold "  Tier 1 complete in $(( ${TIER_END_EPOCH[1]} - tier_start ))s"
 fi
 
 if should_run_tier 2; then
+    CURRENT_TIER=2
     TOTAL_TESTS_IN_TIER=6
     log_bold "\n=========================================="
     log_bold "  TIER 2: Peer Lifecycle ($TOTAL_TESTS_IN_TIER tests)"
     log_bold "=========================================="
     tier_start=$(date +%s)
+    TIER_START_EPOCH[2]=$tier_start
+    emit_event "tier_start" "tier_2" "tests=$TOTAL_TESTS_IN_TIER"
     run_test T5  "Late peer join"                test_t5_late_join
     run_test T6  "Graceful peer leave"           test_t6_graceful_leave
     run_test T7  "Peer crash (SIGKILL)"          test_t7_crash
@@ -1174,15 +1185,20 @@ if should_run_tier 2; then
     run_test T10 "Introducer rejoin"             test_t10_introducer_rejoin
     log_info "Tier 2 data plane gate..."
     verify_data_plane
-    log_bold "  Tier 2 complete in $(( $(date +%s) - tier_start ))s"
+    TIER_END_EPOCH[2]=$(date +%s)
+    emit_event "tier_end" "tier_2"
+    log_bold "  Tier 2 complete in $(( ${TIER_END_EPOCH[2]} - tier_start ))s"
 fi
 
 if should_run_tier 3; then
+    CURRENT_TIER=3
     TOTAL_TESTS_IN_TIER=9
     log_bold "\n=========================================="
     log_bold "  TIER 3: Network Chaos ($TOTAL_TESTS_IN_TIER tests)"
     log_bold "=========================================="
     tier_start=$(date +%s)
+    TIER_START_EPOCH[3]=$tier_start
+    emit_event "tier_start" "tier_3" "tests=$TOTAL_TESTS_IN_TIER"
     run_test T11 "10% packet loss (2 nodes)"     test_t11_loss_10
     run_test T12 "30% packet loss (1 node)"      test_t12_loss_30
     run_test T13 "50% packet loss (flap OK)"     test_t13_loss_50
@@ -1194,15 +1210,20 @@ if should_run_tier 3; then
     run_test T19 "Packet duplication 30%"        test_t19_duplicate
     log_info "Tier 3 data plane gate..."
     verify_data_plane
-    log_bold "  Tier 3 complete in $(( $(date +%s) - tier_start ))s"
+    TIER_END_EPOCH[3]=$(date +%s)
+    emit_event "tier_end" "tier_3"
+    log_bold "  Tier 3 complete in $(( ${TIER_END_EPOCH[3]} - tier_start ))s"
 fi
 
 if should_run_tier 4; then
+    CURRENT_TIER=4
     TOTAL_TESTS_IN_TIER=5
     log_bold "\n=========================================="
     log_bold "  TIER 4: Network Partitions ($TOTAL_TESTS_IN_TIER tests)"
     log_bold "=========================================="
     tier_start=$(date +%s)
+    TIER_START_EPOCH[4]=$tier_start
+    emit_event "tier_start" "tier_4" "tests=$TOTAL_TESTS_IN_TIER"
     run_test T20 "Partial partition"             test_t20_partial_partition
     run_test T21 "Full node isolation"           test_t21_full_isolation
     run_test T22 "Split brain"                   test_t22_split_brain
@@ -1210,29 +1231,39 @@ if should_run_tier 4; then
     run_test T24 "Asymmetric partition"          test_t24_asymmetric
     log_info "Tier 4 data plane gate..."
     verify_data_plane
-    log_bold "  Tier 4 complete in $(( $(date +%s) - tier_start ))s"
+    TIER_END_EPOCH[4]=$(date +%s)
+    emit_event "tier_end" "tier_4"
+    log_bold "  Tier 4 complete in $(( ${TIER_END_EPOCH[4]} - tier_start ))s"
 fi
 
 if should_run_tier 5; then
+    CURRENT_TIER=5
     TOTAL_TESTS_IN_TIER=3
     log_bold "\n=========================================="
     log_bold "  TIER 5: NAT Simulation ($TOTAL_TESTS_IN_TIER tests)"
     log_bold "=========================================="
     tier_start=$(date +%s)
+    TIER_START_EPOCH[5]=$tier_start
+    emit_event "tier_start" "tier_5" "tests=$TOTAL_TESTS_IN_TIER"
     run_test T25 "Cone NAT"                      test_t25_cone_nat
     run_test T26 "Symmetric NAT"                 test_t26_symmetric_nat
     run_test T27 "Mixed NAT topology"            test_t27_mixed_nat
     log_info "Tier 5 data plane gate..."
     verify_data_plane
-    log_bold "  Tier 5 complete in $(( $(date +%s) - tier_start ))s"
+    TIER_END_EPOCH[5]=$(date +%s)
+    emit_event "tier_end" "tier_5"
+    log_bold "  Tier 5 complete in $(( ${TIER_END_EPOCH[5]} - tier_start ))s"
 fi
 
 if should_run_tier 6; then
+    CURRENT_TIER=6
     TOTAL_TESTS_IN_TIER=11
     log_bold "\n=========================================="
     log_bold "  TIER 6: Chaos Monkey ($TOTAL_TESTS_IN_TIER tests)"
     log_bold "=========================================="
     tier_start=$(date +%s)
+    TIER_START_EPOCH[6]=$tier_start
+    emit_event "tier_start" "tier_6" "tests=$TOTAL_TESTS_IN_TIER"
     run_test T28 "Rapid peer cycling"            test_t28_rapid_cycling
     run_test T29 "Rolling restart"               test_t29_rolling_restart
     run_test T30 "Simultaneous restart"          test_t30_simultaneous_restart
@@ -1246,21 +1277,29 @@ if should_run_tier 6; then
     run_test T38 "Stale cache resurrection"      test_t38_stale_cache
     log_info "Tier 6 data plane gate..."
     verify_data_plane
-    log_bold "  Tier 6 complete in $(( $(date +%s) - tier_start ))s"
+    TIER_END_EPOCH[6]=$(date +%s)
+    emit_event "tier_end" "tier_6"
+    log_bold "  Tier 6 complete in $(( ${TIER_END_EPOCH[6]} - tier_start ))s"
 fi
 
 if should_run_tier 7; then
+    CURRENT_TIER=7
     TOTAL_TESTS_IN_TIER=3
     log_bold "\n=========================================="
     log_bold "  TIER 7: Stability Soak ($TOTAL_TESTS_IN_TIER tests)"
     log_bold "=========================================="
     tier_start=$(date +%s)
+    TIER_START_EPOCH[7]=$tier_start
+    emit_event "tier_start" "tier_7" "tests=$TOTAL_TESTS_IN_TIER"
     run_test T39 "5-min clean soak"              test_t39_clean_soak
     run_test T40 "10-min chaos soak"             test_t40_chaos_soak
     run_test T41 "15-min long soak with churn"   test_t41_long_soak
     log_info "Tier 7 data plane gate..."
     verify_data_plane_full   # final comprehensive benchmark
-    log_bold "  Tier 7 complete in $(( $(date +%s) - tier_start ))s"
+    collect_all_pprof  # final profiles after full test suite
+    TIER_END_EPOCH[7]=$(date +%s)
+    emit_event "tier_end" "tier_7"
+    log_bold "  Tier 7 complete in $(( ${TIER_END_EPOCH[7]} - tier_start ))s"
 fi
 
 finish_tests


### PR DESCRIPTION
## Summary

Two major additions to the integration test suite:

### 1. Data Plane Validation (commit 1)

Adds comprehensive data plane verification beyond ICMP ping — validates real TCP/UDP data flows through WireGuard tunnels.

**New helpers:** `mesh_transfer` (netcat + SHA256), `mesh_iperf` (throughput), `mesh_mtu_check` (DF bit)
**Composite:** `verify_data_plane` (all-pairs), `verify_data_plane_quick` (1 pair), `verify_data_plane_full` (benchmark)

Integration: `_chaos_setup` quick check, T2 full benchmark, tier completion gates, Tier 7 final benchmark.

### 2. Test Observability (commit 2)

Three-layer observability system — no external services required.

#### Phase 1: Mermaid Gantt Charts
- Per-test timing recorded with epoch timestamps
- Mermaid Gantt chart in GitHub Actions step summary
- Visual test timeline directly in PR/run page

#### Phase 2: NDJSON Event Tracing + HTML Report
- `emit_event()` writes structured JSON to `trace.jsonl`
- Instrumented: tests, mesh lifecycle, chaos events, data plane metrics, tier boundaries
- `gen-report.py` generates self-contained HTML report with:
  - Timeline visualization (CSS Gantt bars)
  - Chaos event overlay
  - Data plane metrics table (transfer, iperf, MTU)
  - Tier summary statistics
- Report uploaded as GHA artifact alongside test logs

#### Phase 3: Go pprof Flame Graphs
- `--pprof <addr>` flag on `wgmesh join` command
- Starts `net/http/pprof` server (e.g. `localhost:6060`)
- Collection helpers: `collect_pprof_cpu` (30s), `collect_pprof_goroutine`, `collect_pprof_heap`
- `collect_all_pprof` gated behind `WGMESH_PPROF=1` env var
- Profiles collected at Tier 1 (baseline) and Tier 7 (end-state)
- `.prof` artifacts analyzable with `go tool pprof -http=:8080 <file>`

### Files Changed

| File | Changes |
|------|---------|
| `main.go` | `--pprof` flag, `net/http/pprof` import |
| `testlab/cloud/lib.sh` | Data plane helpers, timing arrays, `emit_event()`, Gantt generator, pprof helpers |
| `testlab/cloud/test-cloud.sh` | `CURRENT_TIER` tracking, tier epochs, data plane gates, pprof collection |
| `testlab/cloud/provision.sh` | `netcat-openbsd` dep, pprof flag in systemd unit |
| `testlab/cloud/chaos.sh` | `emit_event` in `chaos_apply`/`chaos_clear` |
| `testlab/cloud/gen-report.py` | New — HTML report generator (~280 lines, stdlib only) |
| `.github/workflows/hetzner-integration.yml` | `WGMESH_PPROF=1`, report generation step |