### PR TITLE
fix: clean up local PID file in mesh_transfer abort and normal paths

### DIFF
--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -350,6 +350,7 @@ mesh_transfer() {
     if [ "$listener_ready" -ne 1 ]; then
         log_error "mesh_transfer $from->$to: listener on $to_ip:$port not reachable after $attempt attempts"
         run_on_ok "$to" "pkill -f 'nc.*-l.*$port' 2>/dev/null; rm -f /tmp/mesh-rx.bin"
+        rm -f "/tmp/_nc_pid_$$"
         return 1
     fi
 
@@ -370,6 +371,7 @@ mesh_transfer() {
     # Cleanup
     run_on_ok "$to" "pkill -f 'nc.*-l.*$port' 2>/dev/null; rm -f /tmp/mesh-rx.bin"
     run_on_ok "$from" "rm -f /tmp/mesh-tx.bin"
+    rm -f "/tmp/_nc_pid_$$"
 
     if [ -z "$src_hash" ] || [ -z "$dst_hash" ]; then
         log_error "mesh_transfer $from->$to: failed to compute checksums (src='$src_hash' dst='$dst_hash')"


### PR DESCRIPTION
## Summary

Addresses Copilot review comment on PR #204: the local `/tmp/_nc_pid_$$` file was not cleaned up on early abort (listener unreachable) or on the normal completion path.

### Fix

- Add `rm -f "/tmp/_nc_pid_$$"` to the early-abort path before `return 1`
- Add `rm -f "/tmp/_nc_pid_$$"` to the normal cleanup section after remote temp files are removed
- Prevents stale PID file accumulation across multiple mesh_transfer invocations