### PR TITLE
fix: address Copilot review comments from PR #206

### DIFF
--- a/.github/workflows/agent-metrics-report.yml
+++ b/.github/workflows/agent-metrics-report.yml
@@ -93,11 +93,12 @@ jobs:
           cd "$METRICS_DIR"
 
           # Collect all JSON into arrays by stage
-          TRIAGE=$(cat agent-metrics-triage-*.json 2>/dev/null | jq -s '.' || echo '[]')
-          SPEC=$(cat agent-metrics-spec-*.json 2>/dev/null | jq -s '.' || echo '[]')
-          GOOSE=$(cat agent-metrics-goose-*.json 2>/dev/null | jq -s '.' || echo '[]')
+          # Use find + cat to handle missing files gracefully (cat with glob fails silently)
+          TRIAGE=$(find . -maxdepth 1 -name 'agent-metrics-triage-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')
+          SPEC=$(find . -maxdepth 1 -name 'agent-metrics-spec-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')
+          GOOSE=$(find . -maxdepth 1 -name 'agent-metrics-goose-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')
           # Merge files contain arrays of PRs; flatten them
-          MERGE=$(cat agent-metrics-merge*.json 2>/dev/null | jq -s 'flatten' || echo '[]')
+          MERGE=$(find . -maxdepth 1 -name 'agent-metrics-merge*.json' -exec cat {} + 2>/dev/null | jq -s 'flatten' 2>/dev/null || echo '[]')
 
           # Calculate DORA metrics
           TOTAL_ISSUES=$(echo "$TRIAGE" | jq 'length')
@@ -212,10 +213,10 @@ jobs:
           jq -n \
             --arg period_start "$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)" \
             --arg period_end "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --argjson triage "$(cat agent-metrics-triage-*.json 2>/dev/null | jq -s '.' || echo '[]')" \
-            --argjson spec "$(cat agent-metrics-spec-*.json 2>/dev/null | jq -s '.' || echo '[]')" \
-            --argjson goose "$(cat agent-metrics-goose-*.json 2>/dev/null | jq -s '.' || echo '[]')" \
-            --argjson merge "$(cat agent-metrics-merge*.json 2>/dev/null | jq -s 'flatten' || echo '[]')" \
+            --argjson triage "$(find . -maxdepth 1 -name 'agent-metrics-triage-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')" \
+            --argjson spec "$(find . -maxdepth 1 -name 'agent-metrics-spec-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')" \
+            --argjson goose "$(find . -maxdepth 1 -name 'agent-metrics-goose-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')" \
+            --argjson merge "$(find . -maxdepth 1 -name 'agent-metrics-merge*.json' -exec cat {} + 2>/dev/null | jq -s 'flatten' 2>/dev/null || echo '[]')" \
             '{
               period: { start: $period_start, end: $period_end },
               triage: $triage,

--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -692,6 +692,7 @@ jobs:
 
           VALIDATE_START=$(date +%s)
           BUILD_PASSED=false; TEST_PASSED=false; VET_PASSED=false; FMT_PASSED=false
+          VALIDATION_FAILED=false
 
           echo "=== Running go build ==="
           BUILD_START=$(date +%s)
@@ -699,44 +700,57 @@ jobs:
             BUILD_PASSED=true
           else
             echo "::error::go build failed on Goose's changes"
+            VALIDATION_FAILED=true
           fi
           BUILD_DUR=$(( $(date +%s) - BUILD_START ))
           echo "validate_build_passed=$BUILD_PASSED" >> $GITHUB_OUTPUT
           echo "validate_build_duration=$BUILD_DUR" >> $GITHUB_OUTPUT
 
-          echo "=== Running go test ==="
-          TEST_START=$(date +%s)
-          if go test ./...; then
-            TEST_PASSED=true
+          # Fail-fast: skip remaining checks if build failed (tests can't run)
+          if [ "$BUILD_PASSED" != "true" ]; then
+            echo "::error::Skipping test/vet/fmt — build failed"
+            echo "validate_test_passed=false" >> $GITHUB_OUTPUT
+            echo "validate_test_duration=0" >> $GITHUB_OUTPUT
+            echo "validate_vet_passed=false" >> $GITHUB_OUTPUT
+            echo "validate_fmt_passed=false" >> $GITHUB_OUTPUT
           else
-            echo "::error::go test failed on Goose's changes"
-          fi
-          TEST_DUR=$(( $(date +%s) - TEST_START ))
-          echo "validate_test_passed=$TEST_PASSED" >> $GITHUB_OUTPUT
-          echo "validate_test_duration=$TEST_DUR" >> $GITHUB_OUTPUT
+            echo "=== Running go test ==="
+            TEST_START=$(date +%s)
+            if go test ./...; then
+              TEST_PASSED=true
+            else
+              echo "::error::go test failed on Goose's changes"
+              VALIDATION_FAILED=true
+            fi
+            TEST_DUR=$(( $(date +%s) - TEST_START ))
+            echo "validate_test_passed=$TEST_PASSED" >> $GITHUB_OUTPUT
+            echo "validate_test_duration=$TEST_DUR" >> $GITHUB_OUTPUT
 
-          echo "=== Running go vet ==="
-          if go vet ./...; then
-            VET_PASSED=true
-          else
-            echo "::error::go vet failed on Goose's changes"
-          fi
-          echo "validate_vet_passed=$VET_PASSED" >> $GITHUB_OUTPUT
+            echo "=== Running go vet ==="
+            if go vet ./...; then
+              VET_PASSED=true
+            else
+              echo "::error::go vet failed on Goose's changes"
+              VALIDATION_FAILED=true
+            fi
+            echo "validate_vet_passed=$VET_PASSED" >> $GITHUB_OUTPUT
 
-          echo "=== Checking gofmt ==="
-          UNFORMATTED=$(gofmt -l .)
-          if [ -z "$UNFORMATTED" ]; then
-            FMT_PASSED=true
-          else
-            echo "::error::gofmt found unformatted files: $UNFORMATTED"
+            echo "=== Checking gofmt ==="
+            UNFORMATTED=$(gofmt -l .)
+            if [ -z "$UNFORMATTED" ]; then
+              FMT_PASSED=true
+            else
+              echo "::error::gofmt found unformatted files: $UNFORMATTED"
+              VALIDATION_FAILED=true
+            fi
+            echo "validate_fmt_passed=$FMT_PASSED" >> $GITHUB_OUTPUT
           fi
-          echo "validate_fmt_passed=$FMT_PASSED" >> $GITHUB_OUTPUT
 
           VALIDATE_DUR=$(( $(date +%s) - VALIDATE_START ))
           echo "validate_duration=$VALIDATE_DUR" >> $GITHUB_OUTPUT
 
-          # Collect diff stats for metrics
-          DIFF_STAT=$(git diff --numstat HEAD 2>/dev/null || true)
+          # Collect diff stats for metrics (compare working tree against main)
+          DIFF_STAT=$(git diff --numstat origin/main 2>/dev/null || true)
           FILES_CHANGED=$(echo "$DIFF_STAT" | grep -c . 2>/dev/null || echo 0)
           INSERTIONS=$(echo "$DIFF_STAT" | awk '{s+=$1}END{print s+0}' 2>/dev/null || echo 0)
           DELETIONS=$(echo "$DIFF_STAT" | awk '{s+=$2}END{print s+0}' 2>/dev/null || echo 0)
@@ -748,8 +762,7 @@ jobs:
           echo "diff_test_files=$TEST_FILES" >> $GITHUB_OUTPUT
           echo "diff_test_insertions=$TEST_INSERTIONS" >> $GITHUB_OUTPUT
 
-          if [ "$BUILD_PASSED" != "true" ] || [ "$TEST_PASSED" != "true" ] || \
-             [ "$VET_PASSED" != "true" ] || [ "$FMT_PASSED" != "true" ]; then
+          if [ "$VALIDATION_FAILED" = "true" ]; then
             echo "::error::Validation failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Fixes 4 Copilot review comments from PR #206 (DORA metrics telemetry):

1. **Restore fail-fast validation** (critical): Build failure now correctly skips test/vet/fmt steps instead of running all checks regardless. The previous change accidentally violated the "zero impact on existing logic" design principle — if `go build` failed, `go test` would still run (pointlessly) and produce misleading metrics.

2. **Fix diff stats calculation**: Changed `git diff --numstat HEAD` to `git diff --numstat origin/main` because at validation time the changes haven't been committed yet, so the HEAD diff always returned zero.

3. **Fix metrics report file collection**: Replaced `cat glob-pattern` with `find -exec cat` to handle the case where no files match the glob. `cat` with a non-matching glob writes an error to stderr (suppressed by `2>/dev/null`) and produces no stdout, causing the `jq -s '.'` pipeline to fail instead of returning `[]`.

## Changes
- `.github/workflows/goose-build.yml` — fail-fast validation + diff stats fix
- `.github/workflows/agent-metrics-report.yml` — robust file collection

## Testing
- YAML validated with `python3 -c "import yaml; yaml.safe_load(open('file'))"`
- No Go code changes