### PR TITLE
fix: address Copilot review comments from PR #207

### DIFF
--- a/.github/workflows/agent-metrics-report.yml
+++ b/.github/workflows/agent-metrics-report.yml
@@ -80,10 +80,22 @@ jobs:
       - name: Extract metrics
         run: |
           cd "$METRICS_DIR"
+          # Extract each artifact zip into a unique subdir to prevent filename collisions
+          # (e.g., multiple merge artifacts each contain agent-metrics-merge.json)
+          i=0
           for zipfile in *.zip; do
             [ -f "$zipfile" ] || continue
-            unzip -o -q "$zipfile" -d . 2>/dev/null || true
-            rm -f "$zipfile"
+            subdir="artifact-$i"
+            mkdir -p "$subdir"
+            unzip -o -q "$zipfile" -d "$subdir" 2>/dev/null || true
+            # Move extracted JSONs to top level with unique names
+            for json in "$subdir"/*.json; do
+              [ -f "$json" ] || continue
+              base=$(basename "$json" .json)
+              mv "$json" "${base}-${i}.json"
+            done
+            rm -rf "$subdir" "$zipfile"
+            i=$((i + 1))
           done
           echo "Extracted JSON files:"
           ls -la *.json 2>/dev/null || echo "No JSON files found"
@@ -93,12 +105,17 @@ jobs:
           cd "$METRICS_DIR"
 
           # Collect all JSON into arrays by stage
-          # Use find + cat to handle missing files gracefully (cat with glob fails silently)
-          TRIAGE=$(find . -maxdepth 1 -name 'agent-metrics-triage-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')
-          SPEC=$(find . -maxdepth 1 -name 'agent-metrics-spec-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')
-          GOOSE=$(find . -maxdepth 1 -name 'agent-metrics-goose-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')
-          # Merge files contain arrays of PRs; flatten them
-          MERGE=$(find . -maxdepth 1 -name 'agent-metrics-merge*.json' -exec cat {} + 2>/dev/null | jq -s 'flatten' 2>/dev/null || echo '[]')
+          # Pass file paths directly to jq -s (avoids cat concat breaking on files without trailing newlines)
+          # In GHA bash (-e -o pipefail) a non-matching glob with plain cat would exit non-zero and fail the step.
+          triage_files=$(find . -maxdepth 1 -name 'agent-metrics-triage-*.json' -print 2>/dev/null)
+          spec_files=$(find . -maxdepth 1 -name 'agent-metrics-spec-*.json' -print 2>/dev/null)
+          goose_files=$(find . -maxdepth 1 -name 'agent-metrics-goose-*.json' -print 2>/dev/null)
+          merge_files=$(find . -maxdepth 1 -name 'agent-metrics-merge-*.json' -print 2>/dev/null)
+
+          TRIAGE=$([ -n "$triage_files" ] && jq -s '.' $triage_files || echo '[]')
+          SPEC=$([ -n "$spec_files" ] && jq -s '.' $spec_files || echo '[]')
+          GOOSE=$([ -n "$goose_files" ] && jq -s '.' $goose_files || echo '[]')
+          MERGE=$([ -n "$merge_files" ] && jq -s 'flatten' $merge_files || echo '[]')
 
           # Calculate DORA metrics
           TOTAL_ISSUES=$(echo "$TRIAGE" | jq 'length')
@@ -210,13 +227,19 @@ jobs:
           cd "$METRICS_DIR"
 
           # Create an aggregated JSON for historical tracking
+          # Reuse the same safe file-list pattern from the report step
+          triage_files=$(find . -maxdepth 1 -name 'agent-metrics-triage-*.json' -print 2>/dev/null)
+          spec_files=$(find . -maxdepth 1 -name 'agent-metrics-spec-*.json' -print 2>/dev/null)
+          goose_files=$(find . -maxdepth 1 -name 'agent-metrics-goose-*.json' -print 2>/dev/null)
+          merge_files=$(find . -maxdepth 1 -name 'agent-metrics-merge-*.json' -print 2>/dev/null)
+
           jq -n \
             --arg period_start "$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)" \
             --arg period_end "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --argjson triage "$(find . -maxdepth 1 -name 'agent-metrics-triage-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')" \
-            --argjson spec "$(find . -maxdepth 1 -name 'agent-metrics-spec-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')" \
-            --argjson goose "$(find . -maxdepth 1 -name 'agent-metrics-goose-*.json' -exec cat {} + 2>/dev/null | jq -s '.' 2>/dev/null || echo '[]')" \
-            --argjson merge "$(find . -maxdepth 1 -name 'agent-metrics-merge*.json' -exec cat {} + 2>/dev/null | jq -s 'flatten' 2>/dev/null || echo '[]')" \
+            --argjson triage "$([ -n "$triage_files" ] && jq -s '.' $triage_files || echo '[]')" \
+            --argjson spec "$([ -n "$spec_files" ] && jq -s '.' $spec_files || echo '[]')" \
+            --argjson goose "$([ -n "$goose_files" ] && jq -s '.' $goose_files || echo '[]')" \
+            --argjson merge "$([ -n "$merge_files" ] && jq -s 'flatten' $merge_files || echo '[]')" \
             '{
               period: { start: $period_start, end: $period_end },
               triage: $triage,

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -268,10 +268,10 @@ jobs:
               }
             }
 
-            // Agent metrics: write collected data
+            // Agent metrics: write collected data (use run_id in filename to avoid overwrite on extraction)
             if (mergeMetrics.length > 0) {
-              const metricsPath = '/tmp/agent-metrics-merge.json';
-              fs.writeFileSync(metricsPath, JSON.stringify(mergeMetrics, null, 2));
+              const metricsPath = `/tmp/agent-metrics-merge-${process.env.GITHUB_RUN_ID}.json`;
+              fs.writeFileSync(metricsPath, JSON.stringify(mergeMetrics, null, 2) + '\n');
               core.info(`Agent metrics: wrote ${mergeMetrics.length} PR records to ${metricsPath}`);
             }
 
@@ -280,6 +280,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: agent-metrics-merge-${{ github.run_id }}
-          path: /tmp/agent-metrics-merge.json
+          path: /tmp/agent-metrics-merge-${{ github.run_id }}.json
           retention-days: 90
           if-no-files-found: ignore

--- a/.github/workflows/copilot-triage.yml
+++ b/.github/workflows/copilot-triage.yml
@@ -152,7 +152,7 @@ jobs:
               copilot_assigned: true,
             };
 
-            fs.writeFileSync(metricsPath, JSON.stringify(metrics, null, 2));
+            fs.writeFileSync(metricsPath, JSON.stringify(metrics, null, 2) + '\n');
             core.info(`Agent metrics: triage latency ${triageLatency}s for issue #${issueNumber}`);
 
       - name: Upload agent metrics


### PR DESCRIPTION
## Summary

Fixes 5 Copilot review comments from PR #207 (metrics report robustness):

1. **Fix JSON concatenation without newlines** (critical): `JSON.stringify()` output lacks trailing newlines, so `cat file1.json file2.json | jq -s` produces `}{` — invalid JSON. Now passes file paths directly to `jq -s` which parses each file independently.

2. **Fix merge artifact overwrite**: Multiple merge metric zips each contained `agent-metrics-merge.json`, so `unzip -o` kept overwriting. Now extracts into unique subdirs and renames with index suffix. Also added `run_id` to the internal merge filename.

3. **Add trailing newline to JSON.stringify outputs**: Both `copilot-triage.yml` and `auto-merge.yml` used `JSON.stringify()` without `+ '\n'`, creating files without trailing newlines.

4. **Fix comment accuracy**: Updated explanation of why `cat` with glob fails (GHA bash uses `-e -o pipefail`, not silent failure).

5. **Fix merge glob pattern**: Changed `agent-metrics-merge*.json` to `agent-metrics-merge-*.json` to match new naming with dash separator.

## Changes
- `.github/workflows/agent-metrics-report.yml` — safe extraction + jq file args
- `.github/workflows/auto-merge.yml` — unique merge metrics filename + trailing newline
- `.github/workflows/copilot-triage.yml` — trailing newline on JSON output

## Testing
- YAML validated with `python3 -c "import yaml; yaml.safe_load(open('file'))"`
- No Go code changes