### PR TITLE
feat: chimney edge infrastructure for cloudroof.eu dashboard

### DIFF
--- a/.github/workflows/chimney-deploy.yml
+++ b/.github/workflows/chimney-deploy.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.23.x'
 
 jobs:
   deploy:
@@ -144,10 +144,10 @@ jobs:
               -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
               docs "root@${ip}:/tmp/docs"
 
-            # Run setup (idempotent)
-            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              "root@${ip}" "GITHUB_TOKEN='${{ secrets.PUSH_TOKEN }}' ROLE=origin bash /tmp/setup.sh"
+            # Run setup (idempotent) — pass token via stdin to avoid exposing in process list
+            echo '${{ secrets.PUSH_TOKEN }}' | ssh -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
+              "root@${ip}" 'read -r GITHUB_TOKEN; export GITHUB_TOKEN; ROLE=origin bash /tmp/setup.sh'
 
             # Health check
             echo "Verifying health on $name..."
@@ -167,8 +167,9 @@ jobs:
             if [ "$HEALTHY" = "true" ]; then
               echo "- **$name** ($ip): deployed successfully" >> "$GITHUB_STEP_SUMMARY"
             else
-              echo "- **$name** ($ip): HEALTH CHECK FAILED" >> "$GITHUB_STEP_SUMMARY"
-              echo "WARNING: $name health check failed — continuing to next server"
+              echo "- **$name** ($ip): HEALTH CHECK FAILED — stopping rollout" >> "$GITHUB_STEP_SUMMARY"
+              echo "ERROR: $name health check failed — aborting rolling deploy to protect remaining servers" >&2
+              exit 1
             fi
 
             echo ""

--- a/.github/workflows/chimney-provision.yml
+++ b/.github/workflows/chimney-provision.yml
@@ -22,7 +22,7 @@ concurrency:
 
 env:
   HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.23.x'
 
 jobs:
   provision:
@@ -105,17 +105,23 @@ jobs:
               IP=$(hcloud server ip "$name")
               echo "Created $name: $IP"
 
-              # Wait for SSH
+              # Wait for SSH with failure detection
               echo "Waiting for SSH on $name ($IP)..."
+              ssh_ready=false
               for i in $(seq 1 30); do
                 if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
                    -o ConnectTimeout=5 -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
                    "root@${IP}" "true" 2>/dev/null; then
                   echo "SSH ready on $name after ${i}0s"
+                  ssh_ready=true
                   break
                 fi
                 sleep 10
               done
+              if [ "$ssh_ready" = "false" ]; then
+                echo "ERROR: SSH did not become ready on $name ($IP) after 300s" >&2
+                exit 1
+              fi
             fi
 
             SERVER_IPS="${SERVER_IPS}${name}=${IP} "
@@ -173,10 +179,10 @@ jobs:
               -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
               docs "root@${IP}:/tmp/docs"
 
-            # Run setup
-            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              "root@${IP}" "GITHUB_TOKEN='${{ secrets.PUSH_TOKEN }}' ROLE=origin bash /tmp/setup.sh"
+            # Run setup — pass token via stdin to avoid exposing in process list
+            echo '${{ secrets.PUSH_TOKEN }}' | ssh -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
+              "root@${IP}" 'read -r GITHUB_TOKEN; export GITHUB_TOKEN; ROLE=origin bash /tmp/setup.sh'
 
             echo "$name deployed successfully"
           done

--- a/deploy/chimney/Caddyfile
+++ b/deploy/chimney/Caddyfile
@@ -2,13 +2,10 @@
 # Caddy handles TLS automatically via Let's Encrypt / ZeroSSL
 #
 # Architecture:
-#   Client → chimney.cloudroof.eu → Caddy (edge) → chimney origin (:8080)
+#   Client → chimney.cloudroof.eu → Caddy (TLS termination) → chimney origin (:8080)
 #
-# Cache strategy:
-#   /api/github/* responses cached at edge for 30s (hot) to 5m (cold)
-#   Static assets cached for 1h
-#   Caddy's cache module provides request coalescing (only one upstream
-#   fetch per cache miss, all other clients wait for the result)
+# Caching is handled by the chimney origin server (in-memory with tiered TTLs),
+# not at the Caddy layer. Caddy acts purely as a TLS-terminating reverse proxy.
 
 chimney.cloudroof.eu {
 	# Reverse proxy to chimney origin server
@@ -22,15 +19,11 @@ chimney.cloudroof.eu {
 	# Response headers
 	header {
 		X-Served-By {system.hostname}
-		X-Cache-Status {http.reverse_proxy.upstream.latency}
 		-Server
 	}
 
-	# Logging
+	# Logging to stdout (captured by systemd journald)
 	log {
-		output file /var/log/caddy/chimney.log {
-			roll_size 50mb
-			roll_keep 3
-		}
+		output stdout
 	}
 }

--- a/deploy/chimney/README.md
+++ b/deploy/chimney/README.md
@@ -5,10 +5,10 @@ chimney is the origin server for the wgmesh pipeline dashboard at `chimney.cloud
 ## Architecture
 
 ```
-                    ┌─────────────────┐
-                    │ chimney.cloud    │
-         ┌────────►│  roof.eu (DNS)   │◄────────┐
-         │         └─────────────────┘         │
+                    ┌──────────────────────┐
+         ┌────────►│ chimney.cloudroof.eu  │◄────────┐
+         │         │       (DNS)           │         │
+         │         └──────────────────────┘         │
          │                                      │
     ┌────┴────┐                           ┌────┴────┐
     │ edge-eu │  Nuremberg (nbg1)         │ edge-us │  Ashburn (ash)

--- a/deploy/chimney/setup.sh
+++ b/deploy/chimney/setup.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 # setup.sh — Bootstrap a chimney edge/origin server on Ubuntu 24.04
 #
-# Usage: SSH_KEY="..." GITHUB_TOKEN="..." ROLE=origin|edge bash setup.sh
+# Usage: GITHUB_TOKEN="..." ROLE=origin|edge bash setup.sh
 #
+# The binary should be pre-deployed to /tmp/chimney by the CI workflow.
 # This script is idempotent — safe to re-run.
 set -euo pipefail
 
 ROLE="${ROLE:-origin}"
 CHIMNEY_USER="chimney"
 CHIMNEY_DIR="/opt/chimney"
-BINARY_URL="${BINARY_URL:-}"  # Set by CI workflow
 
 echo "=== chimney setup (role=$ROLE) ==="
+
+# ── Validate inputs ──
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "WARNING: GITHUB_TOKEN not set — chimney will use unauthenticated GitHub API (60 req/hr)"
+fi
 
 # ── System packages ──
 apt-get update -qq
@@ -21,17 +26,22 @@ apt-get install -y -qq caddy curl jq
 if ! id "$CHIMNEY_USER" &>/dev/null; then
     useradd --system --home-dir "$CHIMNEY_DIR" --shell /usr/sbin/nologin "$CHIMNEY_USER"
 fi
-mkdir -p "$CHIMNEY_DIR" /var/log/caddy
+mkdir -p "$CHIMNEY_DIR"
 chown "$CHIMNEY_USER:$CHIMNEY_USER" "$CHIMNEY_DIR"
 
 # ── Deploy chimney binary ──
-if [ -n "$BINARY_URL" ]; then
-    echo "Downloading chimney binary..."
-    curl -fsSL "$BINARY_URL" -o "$CHIMNEY_DIR/chimney"
-    chmod +x "$CHIMNEY_DIR/chimney"
-elif [ -f /tmp/chimney ]; then
+# The binary is expected at /tmp/chimney, placed there by the CI workflow via scp.
+# We do NOT support downloading from arbitrary URLs for security reasons.
+if [ -f /tmp/chimney ]; then
     cp /tmp/chimney "$CHIMNEY_DIR/chimney"
     chmod +x "$CHIMNEY_DIR/chimney"
+else
+    if [ -f "$CHIMNEY_DIR/chimney" ]; then
+        echo "Using existing chimney binary (no new binary in /tmp)"
+    else
+        echo "ERROR: No chimney binary found at /tmp/chimney or $CHIMNEY_DIR/chimney" >&2
+        exit 1
+    fi
 fi
 
 # ── Deploy dashboard files ──
@@ -41,6 +51,8 @@ if [ -d /tmp/docs ]; then
 fi
 
 # ── Chimney systemd service ──
+# Note: chimney logs to stdout/stderr, captured by systemd journald.
+# No file-based logging — ProtectSystem=strict is safe without extra ReadWritePaths.
 cat > /etc/systemd/system/chimney.service <<EOF
 [Unit]
 Description=chimney origin server (cloudroof.eu dashboard)


### PR DESCRIPTION
## Summary

Replace the client-side GitHub Pages dashboard (60 req/hr unauthenticated) with a server-side caching origin at `chimney.cloudroof.eu` that authenticates to GitHub API (5,000 req/hr).

## Components

### Origin Server (`cmd/chimney/main.go`)
- **GitHub API proxy** at `/api/github/*` with authenticated requests
- **Tiered TTL cache**: 30s for workflow runs, 2min for issues, 5min for closed PRs
- **ETag conditional requests** to GitHub — 304s don't consume rate limit
- **Stale-while-revalidate** — serves cached data if GitHub is down
- **LRU eviction** bounded at 500 cache entries
- `/healthz` health check, `/api/cache/stats` introspection
- Static file serving for dashboard HTML

### Edge Config (`deploy/chimney/`)
- **Caddyfile** — reverse proxy with automatic TLS (Let's Encrypt)
- **setup.sh** — idempotent server bootstrap: Caddy install, systemd service, security hardening (NoNewPrivileges, ProtectSystem=strict, PrivateTmp)

### Workflows
- **chimney-provision.yml** — `workflow_dispatch` to provision/teardown/status Hetzner VMs
  - Supports multi-location (nbg1 EU, ash US)
  - Auto-detects architecture (cax11 Arm64 for EU, cpx11 x86 for US)
  - Builds, deploys, and health-checks in one run
- **chimney-deploy.yml** — Rolling deployment on push to main (when chimney/docs files change)
  - Discovers running chimney servers via `hcloud` labels
  - Builds per-architecture binaries
  - Deploys one server at a time with health verification

## Architecture
```
Client → chimney.cloudroof.eu → Caddy (auto-TLS) → chimney origin (:8080) → GitHub API (5,000 req/hr)
```

## Next Steps After Merge
1. Run `chimney-provision.yml` with `action=provision, locations=nbg1` to create EU server
2. Configure DNS: `chimney.cloudroof.eu` A record pointing to server IP
3. Update `docs/index.html` to use `/api/github/` proxy instead of direct GitHub API calls