### PR TITLE
fix: post-deploy smoke tests + proxy convention for agents

### DIFF
--- a/.github/workflows/chimney-deploy.yml
+++ b/.github/workflows/chimney-deploy.yml
@@ -216,7 +216,8 @@ jobs:
           echo "**$PASS passed, $FAIL failed**" >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$FAIL" -gt 0 ]; then
-            echo "::warning::$FAIL smoke test(s) failed"
+            echo "::error::$FAIL smoke test(s) failed — blocking deploy"
+            exit 1
           fi
 
       - name: Cleanup SSH key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ const res = await fetch(`${API}/pulls`);
   # 3. Proxy/upstream integration returns real data
   # 4. Caching layer responds
   ```
+- **Always read Copilot review comments after every PR merge** — check with `gh api repos/.../pulls/N/comments` and `gh api repos/.../pulls/N/reviews`. If there are actionable comments, create follow-up fix PRs. Do NOT blindly resolve review threads — read them, evaluate, and fix real bugs before resolving.
 
 ## What NOT to Modify
 


### PR DESCRIPTION
## Problem

Dashboard was calling GitHub API directly from browser, bypassing chimney proxy. No automated check caught this — deploy only verified `healthz` returned 200.

## Prevention

### 1. Smoke tests in `chimney-deploy.yml`

Runs after every deploy, verifies 4 endpoints:

| Check | URL | Expects |
|-------|-----|---------|
| healthz | `/healthz` | `"status":"ok"` |
| dashboard HTML | `/` | `Agent Pipeline Dashboard` |
| API proxy | `/api/github/pulls?per_page=1` | `"number"` |
| cache stats | `/api/cache/stats` | `"entries"` |

Results appear in GitHub Actions step summary.

### 2. `AGENTS.md` convention

New "Frontend & API Conventions" section:
> All external API calls MUST go through a local proxy — never call external APIs directly from browser JavaScript.

This ensures Goose, Copilot, and other agents know the rule when writing frontend code.