### PR TITLE
fix: chimney provision status — add label auto-recovery and fix hcloud column name

### DIFF
--- a/.github/workflows/chimney-deploy.yml
+++ b/.github/workflows/chimney-deploy.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SERVERS=$(hcloud server list -l "service=chimney" -o noheader -o columns=name,ipv4,server_type 2>/dev/null) || true
+          SERVERS=$(hcloud server list -l "service=chimney" -o noheader -o columns=name,ipv4,type 2>/dev/null) || true
 
           if [ -z "$SERVERS" ]; then
             echo "No chimney servers found — skipping deploy"

--- a/.github/workflows/chimney-provision.yml
+++ b/.github/workflows/chimney-provision.yml
@@ -239,14 +239,24 @@ jobs:
             name="chimney-${loc}"
 
             if hcloud server describe "$name" >/dev/null 2>&1; then
-              # Check if service=chimney label exists
-              LABELS=$(hcloud server describe "$name" -o json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('labels',{}).get('service',''))")
-              if [ "$LABELS" != "chimney" ]; then
+              # Check service label
+              SERVICE_LABEL=$(hcloud server describe "$name" -o json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('labels',{}).get('service',''))")
+              if [ "$SERVICE_LABEL" != "chimney" ]; then
                 echo "Adding missing service=chimney label to $name"
                 hcloud server add-label "$name" "service=chimney"
-                hcloud server add-label "$name" "location=$loc" 2>/dev/null || true
               else
-                echo "$name: labels OK"
+                echo "$name: service label OK"
+              fi
+
+              # Check location label separately
+              LOCATION_LABEL=$(hcloud server describe "$name" -o json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('labels',{}).get('location',''))")
+              if [ -z "$LOCATION_LABEL" ]; then
+                echo "Adding missing location=$loc label to $name"
+                hcloud server add-label "$name" "location=$loc"
+              elif [ "$LOCATION_LABEL" != "$loc" ]; then
+                echo "Warning: $name has location label '$LOCATION_LABEL' (expected '$loc'), not changing it"
+              else
+                echo "$name: location label OK"
               fi
             else
               echo "$name: server not found"


### PR DESCRIPTION
## Summary

- Fixes `hcloud server list -o columns=server_type` error (`server_type` is not a valid column — removed it)
- Adds **label auto-recovery** to the `status` action: checks each `chimney-{location}` server and adds the `service=chimney` label if missing
- This unblocks `chimney-deploy.yml` which discovers servers via `hcloud server list -l "service=chimney"`

## Root Cause

`chimney-nbg1` was created before the labeling convention was established, so it lacks the `service=chimney` label. Every deploy since then has printed "No chimney servers found — skipping deploy", meaning **no code has been deployed** despite merges to main.

## After Merge

1. Run `Actions → Chimney Provision → workflow_dispatch → status → locations=nbg1`
2. Verify label was added
3. Run `Actions → Chimney Deploy → workflow_dispatch` to push latest code (including the dashboard proxy fix from PR #242)