### PR TITLE
fix: switch Goose from ZAI/GLM-4.7 to Google Gemini 2.0 Flash

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -24,10 +24,9 @@ permissions:
   issues: write
 
 env:
-  GOOSE_PROVIDER: anthropic
-  GOOSE_MODEL: GLM-4.7
-  ANTHROPIC_API_KEY: ${{ secrets.ZAI_API_KEY }}
-  ANTHROPIC_HOST: https://api.z.ai/api/anthropic
+  GOOSE_PROVIDER: google
+  GOOSE_MODEL: gemini-2.0-flash
+  GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
 jobs:
   implement:
@@ -49,10 +48,10 @@ jobs:
       # ── Validate prerequisites ──────────────────────────
       - name: Validate API key is configured
         env:
-          KEY: ${{ secrets.ZAI_API_KEY }}
+          KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           if [ -z "$KEY" ]; then
-            echo "::error::ZAI_API_KEY secret is not configured. Add it in Settings > Secrets > Actions."
+            echo "::error::GOOGLE_API_KEY secret is not configured. Add it in Settings > Secrets > Actions."
             exit 1
           fi
 


### PR DESCRIPTION
## Problem
ZAI proxy (`api.z.ai`) returns **502 Bad Gateway** on tool-use responses. Goose makes one API call, receives 502, prints 'Please retry if you think this is a transient error', and exits 0 with no code changes. All 5 Goose builds triggered today failed this way.

## Root Cause
The ZAI proxy works for text generation (first message) but fails on tool-call follow-up requests. This is a ZAI infrastructure issue, not a Goose or codebase issue.

## Fix
Switch to `GOOGLE_API_KEY` (already a configured secret) with `gemini-2.0-flash` which has full tool-call support and no proxy reliability issues.

## Verification
Will re-trigger Goose builds after merge to confirm implementations proceed.