### PR TITLE
fix: auto-run gofmt in goose-build validation step

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -734,12 +734,14 @@ jobs:
             fi
             echo "validate_vet_passed=$VET_PASSED" >> $GITHUB_OUTPUT
 
-            echo "=== Checking gofmt ==="
+            echo "=== Auto-formatting with gofmt ==="
+            gofmt -w .
             UNFORMATTED=$(gofmt -l .)
             if [ -z "$UNFORMATTED" ]; then
               FMT_PASSED=true
+              echo "gofmt: all files formatted correctly"
             else
-              echo "::error::gofmt found unformatted files: $UNFORMATTED"
+              echo "::error::gofmt found unformatted files even after gofmt -w: $UNFORMATTED"
               VALIDATION_FAILED=true
             fi
             echo "validate_fmt_passed=$FMT_PASSED" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

All 5 Goose builds (issues #247, #253, #254, #257, #259) failed with:

```
gofmt found unformatted files: pkg/lighthouse/dns_test.go pkg/lighthouse/health.go
Validation failed
```

Goose with the Google Gemini provider writes syntactically valid Go code that passes `go build`, `go test`, and `go vet` — but doesn't run `gofmt` on its output before committing.

## Fix

Add `gofmt -w .` before the `gofmt -l` check in the Validate implementation step. Since gofmt is deterministic and idempotent, auto-fixing is safe. The `-l` check remains afterward to catch any edge cases.

## Impact

This unblocks all 5 pending Goose implementations. After this merges, re-trigger the builds.