### PR TITLE
feat: dogfood edge mesh — chimney.cloudroof.eu via WireGuard

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,0 +1,407 @@
+name: Dogfood — Edge Mesh Node
+
+# Provisions an edge node, joins it to the wgmesh with chimney-nbg1 (origin),
+# and configures Caddy to proxy chimney.cloudroof.eu via the WireGuard mesh.
+#
+# Traffic path:
+#   client → chimney.cloudroof.eu (edge public IP)
+#          → Caddy (TLS) → WireGuard mesh → chimney-nbg1:8080 (origin)
+#
+# Requires secrets: HCLOUD_TOKEN, CHIMNEY_SSH_KEY, PUSH_TOKEN
+# Requires a pre-existing mesh secret in: WGMESH_SECRET
+# (Generate once with: wgmesh init -secret, store in repo secret)
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options:
+          - provision-edge
+          - teardown-edge
+          - status
+      edge_location:
+        description: 'Hetzner location for edge node (default: hel1)'
+        required: false
+        default: 'hel1'
+
+concurrency:
+  group: dogfood-edge
+  cancel-in-progress: false
+
+env:
+  HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+  GO_VERSION: '1.23.x'
+  ORIGIN_NAME: chimney-nbg1
+  ORIGIN_IP: 91.99.171.86
+
+jobs:
+  # ── Status ────────────────────────────────────────────────────────────────
+  status:
+    name: Dogfood status
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: inputs.action == 'status'
+    steps:
+      - name: Install hcloud CLI
+        run: |
+          curl -sL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz \
+            | tar xz -C /usr/local/bin hcloud
+
+      - name: List all mesh nodes
+        run: |
+          echo "## Dogfood Mesh Nodes" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          hcloud server list -l "role=origin,service=chimney" -o columns=name,status,ipv4,location 2>/dev/null \
+            || echo "(no origin servers with role=origin label)"
+          echo ""
+          hcloud server list -l "role=edge" -o columns=name,status,ipv4,location 2>/dev/null \
+            || echo "(no edge servers)"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Origin servers (service=chimney):"
+          hcloud server list -l "service=chimney" -o columns=name,status,ipv4,location 2>/dev/null || true
+          echo ""
+          echo "Edge servers (role=edge):"
+          hcloud server list -l "role=edge" -o columns=name,status,ipv4,location 2>/dev/null || true
+
+  # ── Provision Edge ────────────────────────────────────────────────────────
+  provision-edge:
+    name: Provision edge node
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: inputs.action == 'provision-edge'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build wgmesh binary (linux/amd64)
+        run: |
+          # Edge node will be cpx11 (x86) — hel1 doesn't have ARM
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v \
+            -ldflags="-s -w -X main.version=wgmesh-${GITHUB_SHA::8}" \
+            -o wgmesh-linux-amd64 .
+          ls -lh wgmesh-linux-amd64
+
+      - name: Build chimney binary (linux/arm64) for origin bootstrap
+        run: |
+          # chimney-nbg1 is ARM64 (cax11)
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -v \
+            -ldflags="-s -w -X main.version=wgmesh-${GITHUB_SHA::8}" \
+            -o wgmesh-linux-arm64 .
+          ls -lh wgmesh-linux-arm64
+
+      - name: Install hcloud CLI
+        run: |
+          curl -sL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz \
+            | tar xz -C /usr/local/bin hcloud
+          hcloud version
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          echo "${{ secrets.CHIMNEY_SSH_KEY }}" > ~/.ssh/chimney
+          chmod 600 ~/.ssh/chimney
+          ssh-keygen -y -f ~/.ssh/chimney > ~/.ssh/chimney.pub
+          echo "SSH_KEY_FILE=$HOME/.ssh/chimney" >> "$GITHUB_ENV"
+
+      - name: Provision edge server
+        id: provision
+        run: |
+          set -euo pipefail
+          LOC="${{ inputs.edge_location }}"
+          EDGE_NAME="edge-${LOC}"
+
+          # Check if already exists
+          if hcloud server describe "$EDGE_NAME" >/dev/null 2>&1; then
+            echo "Edge server $EDGE_NAME already exists"
+            EDGE_IP=$(hcloud server describe "$EDGE_NAME" -o json | python3 -c "import sys,json; print(json.load(sys.stdin)['public_net']['ipv4']['ip'])")
+          else
+            echo "Creating edge server $EDGE_NAME in $LOC..."
+
+            # Upload SSH key (upsert)
+            KEY_NAME="chimney-deploy-key"
+            hcloud ssh-key delete "$KEY_NAME" 2>/dev/null || true
+            hcloud ssh-key create --name "$KEY_NAME" --public-key-from-file "${SSH_KEY_FILE}.pub"
+
+            # hel1 uses x86 (no ARM available)
+            hcloud server create \
+              --name "$EDGE_NAME" \
+              --type "cpx11" \
+              --image "ubuntu-24.04" \
+              --location "$LOC" \
+              --ssh-key "$KEY_NAME" \
+              --label "role=edge" \
+              --label "location=$LOC"
+
+            EDGE_IP=$(hcloud server describe "$EDGE_NAME" -o json | python3 -c "import sys,json; print(json.load(sys.stdin)['public_net']['ipv4']['ip'])")
+            echo "Created $EDGE_NAME: $EDGE_IP"
+
+            # Wait for SSH
+            echo "Waiting for SSH on $EDGE_NAME ($EDGE_IP)..."
+            for i in $(seq 1 30); do
+              if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+                 -o ConnectTimeout=5 -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
+                 "root@${EDGE_IP}" "true" 2>/dev/null; then
+                echo "SSH ready after ${i}0s"
+                break
+              fi
+              sleep 10
+            done
+          fi
+
+          echo "edge_name=$EDGE_NAME" >> "$GITHUB_OUTPUT"
+          echo "edge_ip=$EDGE_IP" >> "$GITHUB_OUTPUT"
+          echo "EDGE_NAME=$EDGE_NAME" >> "$GITHUB_ENV"
+          echo "EDGE_IP=$EDGE_IP" >> "$GITHUB_ENV"
+
+      - name: Validate or generate mesh secret
+        id: mesh-secret
+        run: |
+          # Use repo secret WGMESH_SECRET if set, otherwise error — we need a stable secret
+          # so both nodes can join the same mesh across multiple workflow runs.
+          if [ -z "${{ secrets.WGMESH_SECRET }}" ]; then
+            echo "ERROR: WGMESH_SECRET repository secret is not set."
+            echo "Generate one with: wgmesh init -secret"
+            echo "Then add it as a repository secret named WGMESH_SECRET."
+            exit 1
+          fi
+          echo "Mesh secret is configured."
+
+      - name: Install wgmesh on edge node
+        run: |
+          set -euo pipefail
+          EDGE_IP="${{ steps.provision.outputs.edge_ip }}"
+
+          # Install system dependencies
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
+            "apt-get update -qq && apt-get install -y -qq wireguard caddy curl"
+
+          # Copy wgmesh binary
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
+            wgmesh-linux-amd64 "root@${EDGE_IP}:/usr/local/bin/wgmesh"
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
+            "chmod +x /usr/local/bin/wgmesh && wgmesh version"
+
+      - name: Install wgmesh on origin (chimney-nbg1)
+        run: |
+          set -euo pipefail
+          ORIGIN_IP="${{ env.ORIGIN_IP }}"
+
+          # Bootstrap SSH access to origin (same key, may already be installed)
+          PUB_KEY=$(cat ~/.ssh/chimney.pub)
+
+          if ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+             -o ConnectTimeout=5 -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
+             "root@${ORIGIN_IP}" "echo ok" 2>/dev/null | grep -q ok; then
+            echo "Bootstrapping SSH to origin via Hetzner password reset..."
+            SERVER_ID=$(hcloud server list -o noheader -o columns=id,ipv4 | awk -v ip="$ORIGIN_IP" '$2==ip{print $1}')
+            RESET_RESP=$(curl -sf -X POST \
+              -H "Authorization: Bearer $HCLOUD_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://api.hetzner.cloud/v1/servers/${SERVER_ID}/actions/reset_password")
+            ROOT_PASS=$(echo "$RESET_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['root_password'])")
+            sleep 5
+            apt-get install -y sshpass 2>/dev/null || true
+            sshpass -p "$ROOT_PASS" ssh -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR \
+              -o PreferredAuthentications=password "root@${ORIGIN_IP}" \
+              "mkdir -p ~/.ssh && chmod 700 ~/.ssh && echo '$PUB_KEY' >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+          fi
+
+          # Install wgmesh on origin
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${ORIGIN_IP}" \
+            "apt-get install -y -qq wireguard 2>/dev/null || true"
+
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
+            wgmesh-linux-arm64 "root@${ORIGIN_IP}:/usr/local/bin/wgmesh"
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${ORIGIN_IP}" \
+            "chmod +x /usr/local/bin/wgmesh && wgmesh version"
+
+      - name: Start wgmesh daemon on origin
+        run: |
+          set -euo pipefail
+          ORIGIN_IP="${{ env.ORIGIN_IP }}"
+          MESH_SECRET="${{ secrets.WGMESH_SECRET }}"
+
+          # Install wgmesh as a systemd service on origin (idempotent)
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${ORIGIN_IP}" \
+            "wgmesh install-service --secret '$MESH_SECRET' 2>/dev/null || true; systemctl restart wgmesh || true"
+
+          # Wait for WireGuard interface to come up and get mesh IP
+          echo "Waiting for wgmesh to assign WireGuard IP on origin..."
+          ORIGIN_WG_IP=""
+          for i in $(seq 1 30); do
+            ORIGIN_WG_IP=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${ORIGIN_IP}" \
+              "ip -4 addr show wg0 2>/dev/null | awk '/inet /{print \$2}' | cut -d/ -f1" 2>/dev/null || true)
+            if [ -n "$ORIGIN_WG_IP" ]; then
+              echo "Origin WireGuard IP: $ORIGIN_WG_IP"
+              break
+            fi
+            sleep 5
+          done
+
+          if [ -z "$ORIGIN_WG_IP" ]; then
+            echo "ERROR: Could not get WireGuard IP from origin after 150s"
+            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${ORIGIN_IP}" \
+              "systemctl status wgmesh --no-pager; journalctl -u wgmesh -n 30 --no-pager" 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "ORIGIN_WG_IP=$ORIGIN_WG_IP" >> "$GITHUB_ENV"
+          echo "origin_wg_ip=$ORIGIN_WG_IP" >> "$GITHUB_OUTPUT"
+
+      - name: Start wgmesh daemon on edge
+        id: edge-wg
+        run: |
+          set -euo pipefail
+          EDGE_IP="${{ steps.provision.outputs.edge_ip }}"
+          MESH_SECRET="${{ secrets.WGMESH_SECRET }}"
+
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
+            "wgmesh install-service --secret '$MESH_SECRET' 2>/dev/null || true; systemctl restart wgmesh || true"
+
+          echo "Waiting for wgmesh to assign WireGuard IP on edge..."
+          EDGE_WG_IP=""
+          for i in $(seq 1 30); do
+            EDGE_WG_IP=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
+              "ip -4 addr show wg0 2>/dev/null | awk '/inet /{print \$2}' | cut -d/ -f1" 2>/dev/null || true)
+            if [ -n "$EDGE_WG_IP" ]; then
+              echo "Edge WireGuard IP: $EDGE_WG_IP"
+              break
+            fi
+            sleep 5
+          done
+
+          if [ -z "$EDGE_WG_IP" ]; then
+            echo "ERROR: Could not get WireGuard IP from edge after 150s"
+            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
+              "systemctl status wgmesh --no-pager; journalctl -u wgmesh -n 30 --no-pager" 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "EDGE_WG_IP=$EDGE_WG_IP" >> "$GITHUB_ENV"
+          echo "edge_wg_ip=$EDGE_WG_IP" >> "$GITHUB_OUTPUT"
+
+      - name: Configure Caddy on edge (proxy via WireGuard mesh)
+        run: |
+          set -euo pipefail
+          EDGE_IP="${{ steps.provision.outputs.edge_ip }}"
+          ORIGIN_WG_IP="${{ env.ORIGIN_WG_IP }}"
+
+          # Verify mesh connectivity: edge should be able to reach origin via WG
+          echo "Testing mesh connectivity: edge → origin ($ORIGIN_WG_IP:8080)..."
+          REACHABLE=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
+            "curl -sf --max-time 5 http://${ORIGIN_WG_IP}:8080/healthz 2>/dev/null && echo ok || echo fail")
+          if [ "$REACHABLE" != "ok" ]; then
+            echo "WARNING: Mesh connectivity test failed — chimney may not be reachable via WG yet"
+            echo "Continuing anyway (Caddy will retry health checks)..."
+          else
+            echo "Mesh connectivity confirmed: edge can reach origin at $ORIGIN_WG_IP:8080"
+          fi
+
+          # Write edge Caddyfile with substituted WireGuard IP
+          CADDYFILE="chimney.cloudroof.eu {
+            reverse_proxy ${ORIGIN_WG_IP}:8080 {
+              health_uri /healthz
+              health_interval 10s
+              health_timeout 3s
+            }
+            header {
+              X-Served-By {system.hostname}
+              X-Edge-Node \"true\"
+              X-Mesh-Origin \"${ORIGIN_WG_IP}\"
+              -Server
+            }
+            log {
+              output stdout
+            }
+          }"
+
+          echo "$CADDYFILE" | ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
+            "cat > /etc/caddy/Caddyfile"
+
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
+            "systemctl enable caddy && systemctl restart caddy && sleep 3 && systemctl status caddy --no-pager"
+
+      - name: Summary
+        run: |
+          EDGE_IP="${{ steps.provision.outputs.edge_ip }}"
+          EDGE_NAME="${{ steps.provision.outputs.edge_name }}"
+          ORIGIN_WG_IP="${{ env.ORIGIN_WG_IP }}"
+          EDGE_WG_IP="${{ env.EDGE_WG_IP }}"
+
+          echo "## Dogfood Mesh — Ready" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Node | Public IP | WireGuard IP |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|-----------|--------------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| chimney-nbg1 (origin) | 91.99.171.86 | ${ORIGIN_WG_IP} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| ${EDGE_NAME} (edge) | ${EDGE_IP} | ${EDGE_WG_IP} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Traffic path:** client → chimney.cloudroof.eu (${EDGE_IP}) → WireGuard mesh → ${ORIGIN_WG_IP}:8080" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Next step:** Update DNS A record for \`chimney.cloudroof.eu\` → \`${EDGE_IP}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "After DNS propagates, test with:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "curl -sf https://chimney.cloudroof.eu/healthz" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+
+          echo ""
+          echo "=== DOGFOOD MESH READY ==="
+          echo "Origin: 91.99.171.86 (WG: $ORIGIN_WG_IP)"
+          echo "Edge:   $EDGE_IP (WG: $EDGE_WG_IP)"
+          echo ""
+          echo "Update DNS: chimney.cloudroof.eu → $EDGE_IP"
+
+  # ── Teardown Edge ─────────────────────────────────────────────────────────
+  teardown-edge:
+    name: Teardown edge node
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: inputs.action == 'teardown-edge'
+    steps:
+      - name: Install hcloud CLI
+        run: |
+          curl -sL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz \
+            | tar xz -C /usr/local/bin hcloud
+
+      - name: Delete edge servers
+        run: |
+          set -euo pipefail
+          EDGE_SERVERS=$(hcloud server list -l "role=edge" -o noheader -o columns=name 2>/dev/null) || true
+
+          if [ -z "$EDGE_SERVERS" ]; then
+            echo "No edge servers found."
+            exit 0
+          fi
+
+          for name in $EDGE_SERVERS; do
+            echo "Deleting $name..."
+            hcloud server delete "$name"
+          done
+
+          echo "Edge servers removed." >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/chimney/Caddyfile.edge
+++ b/deploy/chimney/Caddyfile.edge
@@ -1,0 +1,28 @@
+# Caddyfile for chimney edge nodes (dogfood: traffic via WireGuard mesh)
+# Caddy handles TLS automatically via Let's Encrypt / ZeroSSL
+#
+# Architecture:
+#   Client → chimney.cloudroof.eu (edge IP) → Caddy (TLS termination)
+#          → WireGuard mesh → chimney origin (:8080)
+#
+# WGMESH_ORIGIN_IP is substituted at deploy time with the WireGuard mesh IP
+# of the chimney-nbg1 origin server (e.g. 10.96.0.1).
+
+chimney.cloudroof.eu {
+	# Reverse proxy to chimney origin via WireGuard mesh IP
+	reverse_proxy {$WGMESH_ORIGIN_IP}:8080 {
+		health_uri /healthz
+		health_interval 10s
+		health_timeout 3s
+	}
+
+	header {
+		X-Served-By {system.hostname}
+		X-Edge-Node "true"
+		-Server
+	}
+
+	log {
+		output stdout
+	}
+}


### PR DESCRIPTION
## Summary

Proves the CDN concept by dogfooding wgmesh to serve `chimney.cloudroof.eu` through the mesh.

**Traffic path:** client → `chimney.cloudroof.eu` (edge public IP) → Caddy TLS termination → WireGuard mesh → `chimney-nbg1:8080` (origin)

## Changes

- `.github/workflows/dogfood.yml` — new workflow with 3 actions:
  - `provision-edge`: provisions a Hetzner edge server (default `hel1`), installs wgmesh on both edge and origin, starts the daemon, configures Caddy on edge to proxy via WireGuard mesh IP
  - `teardown-edge`: removes edge server
  - `status`: lists mesh nodes
- `deploy/chimney/Caddyfile.edge` — edge Caddyfile template (for reference; workflow writes it inline with substituted WireGuard IP)

## Prerequisites

- `WGMESH_SECRET` repo secret: already set (generated this session)
- `CHIMNEY_SSH_KEY` repo secret: already set (PR #266)
- `HCLOUD_TOKEN` repo secret: already set

## How to activate

After merge, run:
```
Actions → Dogfood — Edge Mesh Node → Run workflow → provision-edge
```

Then update DNS: `chimney.cloudroof.eu` A record → edge public IP shown in workflow summary.

## Closes

Activates the #1 blocked item: "Deploy mesh + serve HTTP" on the roadmap dashboard.