### PR TITLE
feat: deploy chimney on every main merge with wgmesh version awareness

### DIFF
--- a/.github/workflows/chimney-deploy.yml
+++ b/.github/workflows/chimney-deploy.yml
@@ -3,10 +3,6 @@ name: Chimney Deploy
 on:
   push:
     branches: [main]
-    paths:
-      - 'cmd/chimney/**'
-      - 'deploy/chimney/**'
-      - 'docs/**'
   workflow_dispatch:
 
 concurrency:
@@ -73,6 +69,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Embed wgmesh version: prefer git tag, fall back to module version, then sha
+          WGMESH_TAG=$(git tag --points-at HEAD | grep '^v' | sort -V | tail -1 || true)
+          if [ -n "$WGMESH_TAG" ]; then
+            WGMESH_VERSION="${WGMESH_TAG}"
+          else
+            WGMESH_VERSION="dev-${GITHUB_SHA::8}"
+          fi
+          echo "wgmesh version: ${WGMESH_VERSION}"
+
           NEED_ARM64=false
           NEED_AMD64=false
 
@@ -85,14 +90,14 @@ jobs:
           if [ "$NEED_ARM64" = "true" ]; then
             echo "Building linux/arm64..."
             CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -v \
-              -ldflags="-s -w -X main.version=chimney-${GITHUB_SHA::8}" \
+              -ldflags="-s -w -X main.version=chimney-${GITHUB_SHA::8} -X main.wgmeshVersion=${WGMESH_VERSION}" \
               -o chimney-linux-arm64 ./cmd/chimney/
           fi
 
           if [ "$NEED_AMD64" = "true" ]; then
             echo "Building linux/amd64..."
             CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v \
-              -ldflags="-s -w -X main.version=chimney-${GITHUB_SHA::8}" \
+              -ldflags="-s -w -X main.version=chimney-${GITHUB_SHA::8} -X main.wgmeshVersion=${WGMESH_VERSION}" \
               -o chimney-linux-amd64 ./cmd/chimney/
           fi
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -215,6 +215,14 @@ footer { text-align: center; color: var(--muted); font-size: 0.75rem; padding: 2
 <div class="section-divider">
   <h2>Traction Roadmap &mdash; cloudroof.eu</h2>
   <p>Zero-infrastructure anycast CDN built on WireGuard mesh. Measuring outcomes, not outputs.</p>
+  <p style="margin-top:0.5rem;font-size:0.8125rem;color:var(--muted)">
+    wgmesh live:
+    <span id="traction-wgmesh-version" style="color:var(--accent);font-family:monospace">loading...</span>
+    &middot; open issues: <span id="traction-open-issues" style="color:var(--yellow)">-</span>
+    &middot; open PRs: <span id="traction-open-prs" style="color:var(--accent)">-</span>
+    &middot; Goose pass rate: <span id="traction-goose-rate" style="color:var(--green)">-</span>
+    &middot; last merge: <span id="traction-last-merge" style="color:var(--muted)">-</span>
+  </p>
 </div>
 
 <!-- MSC Progress -->
@@ -923,6 +931,43 @@ let fetchCount = 0;
 let cachedData = {};
 const REFRESH_MS = 300000; // 5 minutes
 
+async function fetchPipelineSummary() {
+  try {
+    // Use chimney's own /api/pipeline/summary endpoint — cached 60s server-side.
+    const origin = window.location.origin;
+    const res = await fetch(`${origin}/api/pipeline/summary`, { cache: 'no-store' });
+    if (!res.ok) return;
+    const data = await res.json();
+
+    const versionEl = document.getElementById('traction-wgmesh-version');
+    if (versionEl) versionEl.textContent = data.wgmesh_version || 'unknown';
+
+    const issuesEl = document.getElementById('traction-open-issues');
+    if (issuesEl) issuesEl.textContent = data.open_issues ?? '-';
+
+    const prsEl = document.getElementById('traction-open-prs');
+    if (prsEl) prsEl.textContent = data.open_prs ?? '-';
+
+    const rateEl = document.getElementById('traction-goose-rate');
+    if (rateEl) {
+      if (data.goose_success_rate_pct != null) {
+        const pct = Math.round(data.goose_success_rate_pct);
+        rateEl.textContent = `${pct}%`;
+        rateEl.style.color = pct >= 80 ? 'var(--green)' : pct >= 60 ? 'var(--yellow)' : 'var(--red)';
+      }
+    }
+
+    const mergeEl = document.getElementById('traction-last-merge');
+    if (mergeEl && data.last_merged_pr) {
+      const pr = data.last_merged_pr;
+      const when = pr.merged_at ? new Date(pr.merged_at).toLocaleDateString() : '';
+      mergeEl.innerHTML = `<a href="https://github.com/atvirokodosprendimai/wgmesh/pull/${pr.number}" target="_blank">#${pr.number}</a> ${when}`;
+    }
+  } catch (e) {
+    console.warn('pipeline/summary fetch failed (local dev?):', e.message);
+  }
+}
+
 async function fetchAll() {
   try {
     fetchCount++;
@@ -1501,7 +1546,9 @@ function renderMem0(gooseRuns) {
 
 // ── Init ──
 fetchAll();
+fetchPipelineSummary(); // chimney-native endpoint — no GitHub rate limit cost
 setInterval(fetchAll, REFRESH_MS); // 5 min — reduces API call volume to stay within unauthenticated rate limits
+setInterval(fetchPipelineSummary, 60000); // refresh pipeline summary every 60s (server-side cached)
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Closes the gap where merging wgmesh code to main **did not redeploy chimney** unless the commit touched \`cmd/chimney/\`, \`deploy/chimney/\`, or \`docs/\`. Now chimney always ships with every main merge.

## Changes

### \`.github/workflows/chimney-deploy.yml\`
- Removed the \`paths:\` filter — chimney now deploys on **every push to main**
- Build step embeds \`wgmesh_version\` via \`-ldflags\`: prefers latest git tag, falls back to \`dev-<sha>\`

### \`cmd/chimney/main.go\`
- Added \`version\` and \`wgmeshVersion\` package-level vars (set at build time)
- New **\`/api/version\`** endpoint — returns \`chimney_version\` + \`wgmesh_version\` as JSON
- New **\`/api/pipeline/summary\`** endpoint — compact pipeline state snapshot:
  - open issue count (excluding PRs), open PR count
  - last merged PR (number, title, SHA, merged_at)
  - recent Goose build outcomes + success rate %
  - Server-side cached 60s (Dragonfly or in-memory) — zero GitHub rate limit cost

### \`docs/index.html\`
- Traction Roadmap header now shows live status bar: wgmesh version, open issues, open PRs, Goose pass rate, last merge link
- New \`fetchPipelineSummary()\` polls \`/api/pipeline/summary\` every 60s (chimney-native, no browser GitHub API calls)

## Why

Every wgmesh merge potentially changes pipeline behaviour, fixes issues, or shifts the traction goals. The dashboard should reflect the **live** state: which wgmesh is deployed, how many issues block activation, whether the Goose pipeline is healthy. Previously a separate commit touching chimney files was required to trigger a redeploy.