### PR TITLE
fix: use --public-key-from-file in rebuild action (hcloud flag fix)

### DIFF
--- a/.github/workflows/chimney-provision.yml
+++ b/.github/workflows/chimney-provision.yml
@@ -335,7 +335,8 @@ jobs:
           # Upload persistent deploy key to Hetzner (replace if exists)
           KEY_NAME="chimney-persistent-key"
           hcloud ssh-key delete "$KEY_NAME" 2>/dev/null || true
-          echo "$CHIMNEY_SSH_PUBKEY" | hcloud ssh-key create --name "$KEY_NAME" --public-key-from-stdin
+          echo "$CHIMNEY_SSH_PUBKEY" > /tmp/chimney-persistent.pub
+          hcloud ssh-key create --name "$KEY_NAME" --public-key-from-file /tmp/chimney-persistent.pub
           KEY_ID=$(hcloud ssh-key describe "$KEY_NAME" -o json | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
           echo "Uploaded persistent key: $KEY_NAME (ID: $KEY_ID)"
 


### PR DESCRIPTION
## Bug

The `rebuild` action added in #281 used \`--public-key-from-stdin\` which doesn't exist in hcloud CLI v1.61.0. Rebuild failed immediately with:

\`\`\`
hcloud: unknown flag: --public-key-from-stdin
\`\`\`

## Fix

Write the pubkey to \`/tmp/chimney-persistent.pub\` and use \`--public-key-from-file\` (the correct flag).