### PR TITLE
chore: force chimney-provision workflow re-registration

### DIFF
--- a/.github/workflows/chimney-provision.yml
+++ b/.github/workflows/chimney-provision.yml
@@ -433,3 +433,4 @@ for k in keys:
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Rebuild complete. Run **Chimney Deploy** workflow to reinstall chimney." >> "$GITHUB_STEP_SUMMARY"
+


### PR DESCRIPTION
GitHub lost the workflow_dispatch registration for chimney-provision.yml after multiple rapid merges. Touching the file forces re-registration.