### PR TITLE
fix: export FINGERPRINT env var for Python subprocess in rebuild action

### DIFF
--- a/.github/workflows/chimney-provision.yml
+++ b/.github/workflows/chimney-provision.yml
@@ -333,12 +333,15 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           # Upload persistent deploy key to Hetzner
-          # Write key to file so we can compute its fingerprint
+          # Write key to file and look up by fingerprint to avoid uniqueness_error
           echo "$CHIMNEY_SSH_PUBKEY" > /tmp/chimney-persistent.pub
           FINGERPRINT=$(ssh-keygen -lf /tmp/chimney-persistent.pub | awk '{print $2}')
+          export FINGERPRINT
 
-          # Check if this exact fingerprint already exists in Hetzner (avoids uniqueness_error)
-          EXISTING_ID=$(hcloud ssh-key list -o json | python3 -c "import sys,json,os; keys=json.load(sys.stdin); [print(k['id']) for k in keys if k.get('fingerprint')==os.environ.get('FINGERPRINT')]" 2>/dev/null || true)
+          # Check if this exact fingerprint already exists in Hetzner (under any name)
+          EXISTING_ID=$(hcloud ssh-key list -o json | python3 -c \
+            "import sys,json,os; keys=json.load(sys.stdin); ids=[str(k['id']) for k in keys if k.get('fingerprint')==os.environ['FINGERPRINT']]; print(ids[0] if ids else '')" \
+            2>/dev/null || true)
 
           if [ -n "$EXISTING_ID" ]; then
             KEY_ID="$EXISTING_ID"


### PR DESCRIPTION
Shell variable FINGERPRINT wasn't in the environment when python3 subprocess ran. Add `export FINGERPRINT` before the python3 call so os.environ['FINGERPRINT'] resolves correctly.