### PR TITLE
chore: force GitHub workflow re-registration for Chimney Provision

### DIFF
--- a/.github/workflows/chimney-provision.yml
+++ b/.github/workflows/chimney-provision.yml
@@ -1,4 +1,5 @@
 name: Chimney Provision
+# re-parse trigger
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
GitHub is showing the workflow as its file path instead of its 'name:' field, which means workflow_dispatch isn't working. This minor comment change forces GitHub to re-parse the YAML and restore the workflow name.