### PR TITLE
fix: replace heredoc with printf in cloud-init generation (YAML parse fix)

### DIFF
--- a/.github/workflows/chimney-provision.yml
+++ b/.github/workflows/chimney-provision.yml
@@ -93,13 +93,9 @@ jobs:
           # This is more reliable than --ssh-key: cloud-init runs after the OS
           # boots and writes directly to authorized_keys, bypassing Hetzner's
           # key injection mechanism which can fail silently on rebuilds.
-          cat > /tmp/cloud-init.yaml << CLOUDINIT
-#cloud-config
-users:
-  - name: root
-    ssh_authorized_keys:
-      - $(cat /tmp/chimney-deploy.pub)
-CLOUDINIT
+          # NOTE: no heredoc here — bare markers at column 0 break YAML parsing.
+          PUB_KEY=$(cat /tmp/chimney-deploy.pub)
+          printf '#cloud-config\nusers:\n  - name: root\n    ssh_authorized_keys:\n      - %s\n' "$PUB_KEY" > /tmp/cloud-init.yaml
           echo "cloud-init user-data prepared:"
           cat /tmp/cloud-init.yaml
 


### PR DESCRIPTION
The cloud-init heredoc added in #290 used bare markers (CLOUDINIT) at column 0 inside a shell `run:` block, which breaks GitHub's YAML workflow parser — same issue as #285. This causes `workflow_dispatch` to be silently unregistered.

Fix: replace the heredoc with a single `printf` command that builds the cloud-init YAML inline.