### PR TITLE
fix: rename dragonfly binary after extraction (tarball uses arch-specific name)

### DIFF
--- a/deploy/chimney/setup.sh
+++ b/deploy/chimney/setup.sh
@@ -37,7 +37,10 @@ if ! command -v dragonfly &>/dev/null; then
     DF_VERSION=$(curl -sf https://api.github.com/repos/dragonflydb/dragonfly/releases/latest | jq -r '.tag_name')
     DF_URL="https://github.com/dragonflydb/dragonfly/releases/download/${DF_VERSION}/dragonfly-${DF_ARCH}.tar.gz"
     echo "Downloading Dragonfly ${DF_VERSION} for ${DF_ARCH}..."
-    curl -sfL "$DF_URL" | tar xz -C /usr/local/bin
+    # The tarball contains "dragonfly-<arch>" binary, not "dragonfly".
+    # Extract to /tmp then rename to get a consistent binary name.
+    curl -sfL "$DF_URL" | tar xz -C /tmp
+    mv "/tmp/dragonfly-${DF_ARCH}" /usr/local/bin/dragonfly
     chmod +x /usr/local/bin/dragonfly
 fi
 


### PR DESCRIPTION
The dragonfly release tarball contains `dragonfly-aarch64` (not `dragonfly`). `setup.sh` was extracting to `/usr/local/bin` and then trying to chmod `/usr/local/bin/dragonfly` which didn't exist, causing the chimney service to fail.

Fix: extract to `/tmp` and rename to `dragonfly` before moving to `/usr/local/bin`.