### PR TITLE
fix: stop chimney service before deploying new binary (avoid 'Text file busy')

### DIFF
--- a/deploy/chimney/setup.sh
+++ b/deploy/chimney/setup.sh
@@ -86,6 +86,9 @@ chown "$CHIMNEY_USER:$CHIMNEY_USER" "$CHIMNEY_DIR"
 # ── Deploy chimney binary ──
 # The binary is expected at /tmp/chimney, placed there by the CI workflow via scp.
 # We do NOT support downloading from arbitrary URLs for security reasons.
+# Stop the running service first to avoid "Text file busy" on the binary.
+systemctl stop chimney 2>/dev/null || true
+
 if [ -f /tmp/chimney ]; then
     cp /tmp/chimney "$CHIMNEY_DIR/chimney"
     chmod +x "$CHIMNEY_DIR/chimney"


### PR DESCRIPTION
On idempotent re-deploys, the chimney binary is already running. Trying to `cp` over a running binary produces `Text file busy`. Stop the chimney service before copying the new binary.