### PR TITLE
fix: create /var/lib/wgmesh on install-service (ProtectSystem=full requires dir to exist)

### DIFF
--- a/pkg/daemon/systemd.go
+++ b/pkg/daemon/systemd.go
@@ -121,6 +121,13 @@ func InstallSystemdService(cfg SystemdServiceConfig) error {
 		return fmt.Errorf("failed to generate unit file: %w", err)
 	}
 
+	// Create state directory (required by ReadWritePaths in systemd unit).
+	// ProtectSystem=full will fail with status=226/NAMESPACE if this dir doesn't exist.
+	stateDir := "/var/lib/wgmesh"
+	if err := os.MkdirAll(stateDir, 0750); err != nil {
+		return fmt.Errorf("failed to create state directory (run as root?): %w", err)
+	}
+
 	// Write secret to environment file with restricted permissions
 	secretDir := "/etc/wgmesh"
 	if err := os.MkdirAll(secretDir, 0700); err != nil {


### PR DESCRIPTION
With `ProtectSystem=full` and `ReadWritePaths=/var/lib/wgmesh` in the systemd unit, the service fails with `status=226/NAMESPACE` if `/var/lib/wgmesh` doesn't exist when systemd tries to set up the mount namespace.

`InstallSystemdService` now creates the state directory (mode 0750) before writing and enabling the service unit.