### PR TITLE
feat: add Cloudflare DNS update workflow for chimney.cloudroof.eu

### DIFF
--- a/.github/workflows/dns-update.yml
+++ b/.github/workflows/dns-update.yml
@@ -1,0 +1,105 @@
+name: DNS Update (Cloudflare)
+
+# Updates the chimney.cloudroof.eu A record to point to the edge node IP.
+# Run this after dogfood provisions a new edge node.
+
+on:
+  workflow_dispatch:
+    inputs:
+      hostname:
+        description: 'Hostname to update (e.g. chimney.cloudroof.eu)'
+        required: true
+        default: 'chimney.cloudroof.eu'
+      target_ip:
+        description: 'New A record value (edge node IP)'
+        required: true
+        default: '65.108.254.61'
+      zone:
+        description: 'Cloudflare zone name'
+        required: true
+        default: 'cloudroof.eu'
+
+jobs:
+  update-dns:
+    name: "Update DNS: ${{ inputs.hostname }} → ${{ inputs.target_ip }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Update Cloudflare DNS record
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          HOSTNAME="${{ inputs.hostname }}"
+          TARGET_IP="${{ inputs.target_ip }}"
+          ZONE_NAME="${{ inputs.zone }}"
+
+          # Get zone ID
+          ZONE_ID=$(curl -sf "https://api.cloudflare.com/client/v4/zones?name=${ZONE_NAME}" \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['result'][0]['id'])")
+          echo "Zone ID: $ZONE_ID"
+
+          # Find the A record
+          RECORD_JSON=$(curl -sf \
+            "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${HOSTNAME}&type=A" \
+            -H "Authorization: Bearer $CF_API_TOKEN")
+          RECORD_COUNT=$(echo "$RECORD_JSON" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['result']))")
+
+          if [ "$RECORD_COUNT" -eq 0 ]; then
+            echo "No A record found for $HOSTNAME — creating..."
+            curl -sf -X POST \
+              "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" \
+              -H "Authorization: Bearer $CF_API_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{\"type\":\"A\",\"name\":\"${HOSTNAME}\",\"content\":\"${TARGET_IP}\",\"ttl\":60,\"proxied\":false}" \
+              | python3 -c "import sys,json; d=json.load(sys.stdin); print('Created:', d['result']['name'], '->', d['result']['content'])"
+          else
+            RECORD_ID=$(echo "$RECORD_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['result'][0]['id'])")
+            CURRENT_IP=$(echo "$RECORD_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['result'][0]['content'])")
+            echo "Current: $HOSTNAME -> $CURRENT_IP (record ID: $RECORD_ID)"
+
+            if [ "$CURRENT_IP" = "$TARGET_IP" ]; then
+              echo "DNS already correct — nothing to do."
+            else
+              echo "Updating $HOSTNAME: $CURRENT_IP -> $TARGET_IP"
+              curl -sf -X PUT \
+                "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RECORD_ID}" \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d "{\"type\":\"A\",\"name\":\"${HOSTNAME}\",\"content\":\"${TARGET_IP}\",\"ttl\":60,\"proxied\":false}" \
+                | python3 -c "import sys,json; d=json.load(sys.stdin); print('Updated:', d['result']['name'], '->', d['result']['content'])"
+            fi
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "## DNS Update Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Hostname | \`${HOSTNAME}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| New IP | \`${TARGET_IP}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Zone | \`${ZONE_NAME}\` |" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify propagation
+        run: |
+          set -euo pipefail
+          HOSTNAME="${{ inputs.hostname }}"
+          TARGET_IP="${{ inputs.target_ip }}"
+
+          echo "Waiting for DNS propagation..."
+          for i in $(seq 1 12); do
+            RESOLVED=$(dig +short "$HOSTNAME" A @1.1.1.1 2>/dev/null | head -1)
+            echo "  Attempt $i: $HOSTNAME -> ${RESOLVED:-not resolved}"
+            if [ "$RESOLVED" = "$TARGET_IP" ]; then
+              echo "DNS propagated successfully."
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "DNS propagated via 1.1.1.1 in ~$((i*5))s" >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "WARNING: DNS not yet propagated via 1.1.1.1 after 60s (may still be in progress)"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "DNS propagation pending (check again in a few minutes)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds a `DNS Update (Cloudflare)` workflow that updates the A record for `chimney.cloudroof.eu` to point to the edge node IP.

Requires `CLOUDFLARE_API_TOKEN` GitHub secret to be set. After adding the secret, run:
```
Actions → DNS Update (Cloudflare) → Run workflow
hostname: chimney.cloudroof.eu
target_ip: 65.108.254.61
zone: cloudroof.eu
```