### PR TITLE
chore: migrate chimney domain to chimney.beerpub.dev

### DIFF
--- a/.github/workflows/chimney-deploy.yml
+++ b/.github/workflows/chimney-deploy.yml
@@ -270,18 +270,18 @@ jobs:
             fi
           }
 
-          echo "Running smoke tests against chimney.cloudroof.eu..."
+          echo "Running smoke tests against chimney.beerpub.dev..."
           check "healthz returns ok" \
-            "https://chimney.cloudroof.eu/healthz" '"status":"ok"'
+            "https://chimney.beerpub.dev/healthz" '"status":"ok"'
 
           check "dashboard HTML loads" \
-            "https://chimney.cloudroof.eu/" "Agent Pipeline Dashboard"
+            "https://chimney.beerpub.dev/" "Agent Pipeline Dashboard"
 
           check "GitHub API proxy returns data" \
-            "https://chimney.cloudroof.eu/api/github/pulls?per_page=1&state=all" '"number"'
+            "https://chimney.beerpub.dev/api/github/pulls?per_page=1&state=all" '"number"'
 
           check "cache stats endpoint works" \
-            "https://chimney.cloudroof.eu/api/cache/stats" '"entries"'
+            "https://chimney.beerpub.dev/api/cache/stats" '"entries"'
 
           echo ""
           echo "Results: $PASS passed, $FAIL failed"

--- a/.github/workflows/chimney-provision.yml
+++ b/.github/workflows/chimney-provision.yml
@@ -220,7 +220,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "## Deployment Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Dashboard should be available at https://chimney.cloudroof.eu once DNS is configured." >> "$GITHUB_STEP_SUMMARY"
+          echo "Dashboard should be available at https://chimney.beerpub.dev once DNS is configured." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify health
         run: |

--- a/.github/workflows/dns-update.yml
+++ b/.github/workflows/dns-update.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       hostname:
-        description: 'Hostname to update (e.g. chimney.cloudroof.eu)'
+        description: 'Hostname to update (e.g. chimney.beerpub.dev)'
         required: true
-        default: 'chimney.cloudroof.eu'
+        default: 'chimney.beerpub.dev'
       target_ip:
         description: 'New A record value (edge node IP)'
         required: true
@@ -17,7 +17,7 @@ on:
       zone:
         description: 'Cloudflare zone name'
         required: true
-        default: 'cloudroof.eu'
+        default: 'beerpub.dev'
 
 jobs:
   update-dns:

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,10 +1,10 @@
 name: Dogfood — Edge Mesh Node
 
 # Provisions an edge node, joins it to the wgmesh with chimney-nbg1 (origin),
-# and configures Caddy to proxy chimney.cloudroof.eu via the WireGuard mesh.
+# and configures Caddy to proxy chimney.beerpub.dev via the WireGuard mesh.
 #
 # Traffic path:
-#   client → chimney.cloudroof.eu (edge public IP)
+#   client → chimney.beerpub.dev (edge public IP)
 #          → Caddy (TLS) → WireGuard mesh → chimney-nbg1:8080 (origin)
 #
 # Requires secrets: HCLOUD_TOKEN, CHIMNEY_SSH_KEY, PUSH_TOKEN
@@ -326,7 +326,7 @@ jobs:
           fi
 
           # Write edge Caddyfile with substituted WireGuard IP
-          CADDYFILE="chimney.cloudroof.eu {
+          CADDYFILE="chimney.beerpub.dev {
             reverse_proxy ${ORIGIN_WG_IP}:8080 {
               health_uri /healthz
               health_interval 10s
@@ -365,13 +365,13 @@ jobs:
           echo "| chimney-nbg1 (origin) | 91.99.171.86 | ${ORIGIN_WG_IP} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| ${EDGE_NAME} (edge) | ${EDGE_IP} | ${EDGE_WG_IP} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Traffic path:** client → chimney.cloudroof.eu (${EDGE_IP}) → WireGuard mesh → ${ORIGIN_WG_IP}:8080" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Traffic path:** client → chimney.beerpub.dev (${EDGE_IP}) → WireGuard mesh → ${ORIGIN_WG_IP}:8080" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Next step:** Update DNS A record for \`chimney.cloudroof.eu\` → \`${EDGE_IP}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Next step:** Update DNS A record for \`chimney.beerpub.dev\` → \`${EDGE_IP}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "After DNS propagates, test with:" >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "curl -sf https://chimney.cloudroof.eu/healthz" >> "$GITHUB_STEP_SUMMARY"
+          echo "curl -sf https://chimney.beerpub.dev/healthz" >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
           echo ""
@@ -379,7 +379,7 @@ jobs:
           echo "Origin: 91.99.171.86 (WG: $ORIGIN_WG_IP)"
           echo "Edge:   $EDGE_IP (WG: $EDGE_WG_IP)"
           echo ""
-          echo "Update DNS: chimney.cloudroof.eu → $EDGE_IP"
+          echo "Update DNS: chimney.beerpub.dev → $EDGE_IP"
 
   # ── Teardown Edge ─────────────────────────────────────────────────────────
   teardown-edge:

--- a/deploy/chimney/Caddyfile
+++ b/deploy/chimney/Caddyfile
@@ -2,12 +2,12 @@
 # Caddy handles TLS automatically via Let's Encrypt / ZeroSSL
 #
 # Architecture:
-#   Client → chimney.cloudroof.eu → Caddy (TLS termination) → chimney origin (:8080)
+#   Client → chimney.beerpub.dev → Caddy (TLS termination) → chimney origin (:8080)
 #
 # Caching is handled by the chimney origin server (in-memory with tiered TTLs),
 # not at the Caddy layer. Caddy acts purely as a TLS-terminating reverse proxy.
 
-chimney.cloudroof.eu {
+chimney.beerpub.dev {
 	# Reverse proxy to chimney origin server
 	reverse_proxy localhost:8080 {
 		# Health check

--- a/deploy/chimney/Caddyfile.edge
+++ b/deploy/chimney/Caddyfile.edge
@@ -2,13 +2,13 @@
 # Caddy handles TLS automatically via Let's Encrypt / ZeroSSL
 #
 # Architecture:
-#   Client → chimney.cloudroof.eu (edge IP) → Caddy (TLS termination)
+#   Client → chimney.beerpub.dev (edge IP) → Caddy (TLS termination)
 #          → WireGuard mesh → chimney origin (:8080)
 #
 # WGMESH_ORIGIN_IP is substituted at deploy time with the WireGuard mesh IP
 # of the chimney-nbg1 origin server (e.g. 10.96.0.1).
 
-chimney.cloudroof.eu {
+chimney.beerpub.dev {
 	# Reverse proxy to chimney origin via WireGuard mesh IP
 	reverse_proxy {$WGMESH_ORIGIN_IP}:8080 {
 		health_uri /healthz


### PR DESCRIPTION
## Summary

- Replaces all `chimney.cloudroof.eu` references with `chimney.beerpub.dev`
- Updates `dns-update.yml` default zone to `beerpub.dev` 
- Updates both Caddyfiles (origin + edge) to serve the new hostname
- `CLOUDFLARE_API_TOKEN` secret now holds a zone-scoped token for `beerpub.dev`

## Next steps after merge

1. Run **Chimney Deploy** to push updated Caddyfile to origin (`chimney-nbg1`) — this will get a TLS cert for `chimney.beerpub.dev`
2. Run **Dogfood — Edge Mesh Node** to reprovision edge with updated Caddyfile
3. Run **DNS Update (Cloudflare)** to point `chimney.beerpub.dev → 65.108.254.61` (edge IP)