### PR TITLE
fix: stop wgmesh before binary copy in dogfood workflow

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -199,6 +199,11 @@ jobs:
             EDGE_BINARY="wgmesh-linux-arm64"
           fi
 
+          # Stop wgmesh before copying to avoid "Text file busy" on redeployment
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
+            "systemctl stop wgmesh 2>/dev/null || true"
+
           # Copy wgmesh binary
           scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
             -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
@@ -207,7 +212,7 @@ jobs:
             -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
             "chmod +x /usr/local/bin/wgmesh && wgmesh version"
 
-      - name: Install wgmesh on origin (chimney-nbg1)
+       - name: Install wgmesh on origin (chimney-nbg1)
         run: |
           set -euo pipefail
           ORIGIN_IP="${{ env.ORIGIN_IP }}"
@@ -228,6 +233,11 @@ jobs:
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
             -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${ORIGIN_IP}" \
             "apt-get install -y -qq wireguard 2>/dev/null || true"
+
+          # Stop wgmesh before copying to avoid "Text file busy" on redeployment
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${ORIGIN_IP}" \
+            "systemctl stop wgmesh 2>/dev/null || true"
 
           scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
             -o LogLevel=ERROR -i "$SSH_KEY_FILE" \


### PR DESCRIPTION
## Problem

Rerunning the dogfood workflow on an existing edge node fails with:

```
scp: dest open "/usr/local/bin/wgmesh": Failure
scp: failed to upload file wgmesh-linux-arm64 to /usr/local/bin/wgmesh
```

The wgmesh daemon is running and has the binary file locked, causing SCP to fail.

## Fix

Add `systemctl stop wgmesh` before the SCP step for both edge and origin nodes. Same fix was previously applied to `deploy/chimney/setup.sh` for the chimney binary.