### PR TITLE
fix: rename dogfood workflow em-dash to hyphen

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,4 +1,4 @@
-name: Dogfood — Edge Mesh Node
+name: Dogfood - Edge Mesh Node
 
 # Provisions an edge node, joins it to the wgmesh with chimney-nbg1 (origin),
 # and configures Caddy to proxy chimney.beerpub.dev via the WireGuard mesh.


### PR DESCRIPTION
The em-dash (—) in 'Dogfood — Edge Mesh Node' causes GitHub's workflow_dispatch API to return HTTP 422 'Workflow does not have workflow_dispatch trigger', even though the trigger is present in the YAML. Replacing with a regular hyphen fixes registration.