### PR TITLE
chore: force dogfood workflow re-registration

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -10,6 +10,7 @@ name: Dogfood - Edge Mesh Node
 # Requires secrets: HCLOUD_TOKEN, CHIMNEY_SSH_KEY, PUSH_TOKEN
 # Requires a pre-existing mesh secret in: WGMESH_SECRET
 # (Generate once with: wgmesh init -secret, store in repo secret)
+# Force re-registration: 2026-02-20
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Forces GitHub to re-index the dogfood workflow so workflow_dispatch works after the em-dash → hyphen rename.