### PR TITLE
fix: correct YAML indentation in dogfood workflow

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -213,7 +213,7 @@ jobs:
             -o LogLevel=ERROR -i "$SSH_KEY_FILE" "root@${EDGE_IP}" \
             "chmod +x /usr/local/bin/wgmesh && wgmesh version"
 
-       - name: Install wgmesh on origin (chimney-nbg1)
+      - name: Install wgmesh on origin (chimney-nbg1)
         run: |
           set -euo pipefail
           ORIGIN_IP="${{ env.ORIGIN_IP }}"


### PR DESCRIPTION
Step 'Install wgmesh on origin' had 7-space indent instead of 6, causing YAML parse failure. GitHub silently refuses workflow_dispatch for invalid YAML workflows.