### PR TITLE
fix: update smoke test cache stats key (entries → mem_entries)

### DIFF
--- a/.github/workflows/chimney-deploy.yml
+++ b/.github/workflows/chimney-deploy.yml
@@ -281,7 +281,7 @@ jobs:
             "https://chimney.beerpub.dev/api/github/pulls?per_page=1&state=all" '"number"'
 
           check "cache stats endpoint works" \
-            "https://chimney.beerpub.dev/api/cache/stats" '"entries"'
+            "https://chimney.beerpub.dev/api/cache/stats" '"mem_entries"'
 
           echo ""
           echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
The cache stats endpoint returns `mem_entries` not `entries`. Fixes the smoke test false failure in Chimney Deploy.