### PR TITLE
feat: add pkg/proxy — HTTP reverse proxy for lighthouse edge nodes (#273)

### DIFF
--- a/cmd/lighthouse/main.go
+++ b/cmd/lighthouse/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/atvirokodosprendimai/wgmesh/pkg/lighthouse"
+	"github.com/atvirokodosprendimai/wgmesh/pkg/proxy"
 	"github.com/atvirokodosprendimai/wgmesh/pkg/ratelimit"
 )
 
@@ -42,6 +43,8 @@ func main() {
 	dnsTarget := flag.String("dns-target", "edge.cloudroof.eu", "DNS target for customer CNAME")
 	rateLimitRPS := flag.Float64("rate-limit-rps", 100, "Rate limit: requests per second per API key (0 to disable)")
 	rateLimitBurst := flag.Int("rate-limit-burst", 200, "Rate limit: burst size per API key")
+	proxyAddr := flag.String("proxy-addr", "", "address to listen for proxy traffic (e.g. :8081)")
+	proxyOrigins := flag.String("proxy-origins", "", "comma-separated domain=url pairs for reverse proxy (e.g. example.com=http://10.0.0.2:3000)")
 
 	var peers stringSlice
 	flag.Var(&peers, "peer", "Mesh IP of another lighthouse instance (repeatable)")
@@ -109,6 +112,32 @@ func main() {
 		log.Printf("Mesh sync active — federated replication enabled")
 	} else {
 		log.Printf("WARNING: No mesh IP configured — running standalone (no federation)")
+	}
+
+	// Start reverse proxy listener if configured.
+	if *proxyAddr != "" {
+		origins := make(map[string]string)
+		for _, pair := range strings.Split(*proxyOrigins, ",") {
+			pair = strings.TrimSpace(pair)
+			if pair == "" {
+				continue
+			}
+			idx := strings.IndexByte(pair, '=')
+			if idx <= 0 {
+				log.Fatalf("proxy: invalid origin pair %q (expected domain=url)", pair)
+			}
+			origins[strings.TrimSpace(pair[:idx])] = strings.TrimSpace(pair[idx+1:])
+		}
+		p, err := proxy.New(origins)
+		if err != nil {
+			log.Fatalf("proxy: %v", err)
+		}
+		log.Printf("proxy starting on %s (%d origins)", *proxyAddr, len(origins))
+		go func() {
+			if err := http.ListenAndServe(*proxyAddr, p); err != nil {
+				log.Printf("proxy error: %v", err)
+			}
+		}()
 	}
 
 	if err := http.ListenAndServe(*addr, mux); err != nil {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,81 @@
+// Package proxy implements an HTTP reverse proxy that routes incoming
+// requests to upstream origins based on the request's Host header.
+//
+// Intended for use in the lighthouse/edge nodes to serve registered
+// customer sites by forwarding traffic through the WireGuard mesh.
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Proxy is an HTTP handler that routes requests to upstream origins
+// based on the Host header. Unknown hosts receive a 502 response.
+type Proxy struct {
+	origins map[string]*url.URL
+}
+
+// New creates a Proxy from a map of domain → upstream URL strings.
+// Each value must be a valid URL (e.g. "http://10.0.0.2:3000").
+// Returns an error if any URL fails to parse.
+func New(origins map[string]string) (*Proxy, error) {
+	parsed := make(map[string]*url.URL, len(origins))
+	for domain, raw := range origins {
+		if raw == "" {
+			return nil, fmt.Errorf("proxy: empty URL for domain %q", domain)
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			return nil, fmt.Errorf("proxy: invalid URL for domain %q: %w", domain, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("proxy: URL for domain %q must include scheme and host", domain)
+		}
+		parsed[domain] = u
+	}
+	return &Proxy{origins: parsed}, nil
+}
+
+// ServeHTTP implements http.Handler. It strips the port from the Host
+// header, looks up the registered origin, and proxies the request.
+// Returns 502 if no origin is registered for the host.
+func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	host := r.Host
+	// Strip port if present (e.g. "example.com:80" → "example.com")
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.ToLower(host)
+
+	target, ok := p.origins[host]
+	if !ok {
+		http.Error(w, "502 Bad Gateway — no origin registered for host", http.StatusBadGateway)
+		return
+	}
+
+	rp := httputil.NewSingleHostReverseProxy(target)
+	rp.Transport = &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 10 * time.Second,
+		}).DialContext,
+	}
+	// Preserve the original Host for the upstream and set X-Forwarded-Host
+	rp.Director = func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.Host = target.Host
+		req.Header.Set("X-Forwarded-Host", r.Host)
+		if r.TLS != nil {
+			req.Header.Set("X-Forwarded-Proto", "https")
+		} else {
+			req.Header.Set("X-Forwarded-Proto", "http")
+		}
+	}
+	rp.ServeHTTP(w, r)
+}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1,0 +1,114 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestProxy_ServeHTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		makeOrigins  func(originURL string) map[string]string
+		requestHost  string
+		wantStatus   int
+		wantBodyHint string
+	}{
+		{
+			name:         "known host proxies to origin",
+			makeOrigins:  func(u string) map[string]string { return map[string]string{"example.com": u} },
+			requestHost:  "example.com",
+			wantStatus:   http.StatusOK,
+			wantBodyHint: "origin-ok",
+		},
+		{
+			name:        "unknown host returns 502",
+			makeOrigins: func(u string) map[string]string { return map[string]string{"example.com": u} },
+			requestHost: "unknown.com",
+			wantStatus:  http.StatusBadGateway,
+		},
+		{
+			name:        "host with port strips port for lookup",
+			makeOrigins: func(u string) map[string]string { return map[string]string{"example.com": u} },
+			requestHost: "example.com:80",
+			wantStatus:  http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Each subtest owns its origin server — avoid close-before-use race.
+			origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("origin-ok"))
+			}))
+			t.Cleanup(origin.Close)
+
+			p, err := New(tt.makeOrigins(origin.URL))
+			if err != nil {
+				t.Fatalf("New() unexpected error: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "http://"+tt.requestHost+"/", nil)
+			req.Host = tt.requestHost
+			rr := httptest.NewRecorder()
+
+			p.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d; body: %s", rr.Code, tt.wantStatus, rr.Body.String())
+			}
+			if tt.wantBodyHint != "" && !strings.Contains(rr.Body.String(), tt.wantBodyHint) {
+				t.Errorf("body = %q, want to contain %q", rr.Body.String(), tt.wantBodyHint)
+			}
+		})
+	}
+}
+
+func TestNew_Error(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		origins map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "empty URL returns error",
+			origins: map[string]string{"example.com": ""},
+			wantErr: true,
+		},
+		{
+			name:    "URL without scheme returns error",
+			origins: map[string]string{"example.com": "10.0.0.1:3000"},
+			wantErr: true,
+		},
+		{
+			name:    "valid URL succeeds",
+			origins: map[string]string{"example.com": "http://10.0.0.1:3000"},
+			wantErr: false,
+		},
+		{
+			name:    "empty origins map succeeds",
+			origins: map[string]string{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := New(tt.origins)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the **#1 roadmap blocker**: edge nodes can now proxy HTTP traffic for registered sites.

- New `pkg/proxy` package: `Proxy` routes by `Host` header → upstream `map[string]*url.URL`. Returns 502 for unknown hosts. Sets `X-Forwarded-Host` / `X-Forwarded-Proto`.
- 7 table-driven tests passing with `-race`: proxies to origin, 502 on unknown host, port stripping, URL parse errors.
- `cmd/lighthouse/main.go`: `--proxy-addr :8081 --proxy-origins example.com=http://10.0.0.2:3000` starts a second listener.

Closes #273