### PR TITLE
fix: ensure chimney waits for Dragonfly with Requires= and retry loop

### DIFF
--- a/deploy/chimney/setup.sh
+++ b/deploy/chimney/setup.sh
@@ -112,9 +112,9 @@ fi
 # No file-based logging — ProtectSystem=strict is safe without extra ReadWritePaths.
 cat > /etc/systemd/system/chimney.service <<EOF
 [Unit]
-Description=chimney origin server (cloudroof.eu dashboard)
+Description=chimney origin server (beerpub.dev dashboard)
 After=network.target dragonfly.service
-Wants=dragonfly.service
+Requires=dragonfly.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Problem

`/healthz` reports `"dragonfly":"disabled"` on `chimney-nbg1` despite Dragonfly being installed and running on `127.0.0.1:6379`.

**Root cause**: Two races at startup:
1. systemd `Wants=dragonfly.service` is a soft dependency — chimney starts even if Dragonfly is still starting up
2. A single ping attempt with no retry — if Dragonfly isn't listening yet, `useRedis` is permanently set to `false`

## Fix

- **`deploy/chimney/setup.sh`**: `Wants=` → `Requires=dragonfly.service` — systemd will not start chimney until Dragonfly has been started
- **`cmd/chimney/main.go`**: Replace single ping with 10-attempt retry loop (1s backoff) — handles the window where Dragonfly is started but not yet accepting TCP connections
- Also fixes two stale `cloudroof.eu` references in comments/description

## Verification

After deploying via `chimney-deploy` workflow, `/healthz` should show `"dragonfly":"connected"`.