### PR TITLE
feat: migrate chimney deployment to Docker Compose (cattle not pets)

### DIFF
--- a/.github/workflows/chimney-deploy.yml
+++ b/.github/workflows/chimney-deploy.yml
@@ -198,34 +198,35 @@ jobs:
             echo "=== Deploying to $name ($ip, $arch) ==="
             BINARY="chimney-linux-${arch}"
 
-            # Copy binary
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              "$BINARY" "root@${ip}:/tmp/chimney"
+            SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i $SSH_KEY_FILE"
 
-            # Copy deploy scripts and config
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              deploy/chimney/setup.sh "root@${ip}:/tmp/setup.sh"
+            # Copy chimney binary
+            $SCP "$BINARY" "root@${ip}:/tmp/chimney"
 
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              deploy/chimney/Caddyfile "root@${ip}:/tmp/Caddyfile"
+            # Copy compose stack files
+            $SCP deploy/chimney/setup.sh    "root@${ip}:/tmp/setup.sh"
+            $SCP deploy/chimney/compose.yml "root@${ip}:/tmp/compose.yml"
+            $SCP deploy/chimney/Caddyfile   "root@${ip}:/tmp/Caddyfile"
+            $SCP deploy/chimney/Dockerfile  "root@${ip}:/tmp/Dockerfile"
 
             # Copy dashboard
-            scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              docs "root@${ip}:/tmp/docs"
+            $SCP -r docs "root@${ip}:/tmp/docs"
 
-            # Run setup (idempotent) — pass token via stdin to avoid exposing in process list
-            echo '${{ secrets.PUSH_TOKEN }}' | ssh -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              "root@${ip}" 'read -r GITHUB_TOKEN; export GITHUB_TOKEN; ROLE=origin bash /tmp/setup.sh'
+            # Run setup (idempotent) — pass secrets via stdin, never in env/args
+            printf '%s\n%s\n' \
+              '${{ secrets.PUSH_TOKEN }}' \
+              '${{ secrets.WGMESH_SECRET }}' \
+            | ssh -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
+                "root@${ip}" \
+                'read -r GITHUB_TOKEN; read -r WGMESH_SECRET
+                 export GITHUB_TOKEN WGMESH_SECRET
+                 ROLE=origin bash /tmp/setup.sh'
 
-            # Health check
+            # Health check — chimney is now behind Docker, check via curl on port 8080
             echo "Verifying health on $name..."
             HEALTHY=false
-            for i in $(seq 1 12); do
+            for i in $(seq 1 20); do
               if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
                  -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
                  "root@${ip}" "curl -sf http://localhost:8080/healthz" 2>/dev/null; then

--- a/.github/workflows/chimney-provision.yml
+++ b/.github/workflows/chimney-provision.yml
@@ -192,27 +192,24 @@ jobs:
             echo "Deploying to $name ($IP, $ARCH)..."
 
             # Copy files to server
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              "$BINARY" "root@${IP}:/tmp/chimney"
+            SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i $SSH_KEY_FILE"
+            $SCP "$BINARY"                    "root@${IP}:/tmp/chimney"
+            $SCP deploy/chimney/setup.sh      "root@${IP}:/tmp/setup.sh"
+            $SCP deploy/chimney/compose.yml   "root@${IP}:/tmp/compose.yml"
+            $SCP deploy/chimney/Caddyfile     "root@${IP}:/tmp/Caddyfile"
+            $SCP deploy/chimney/Dockerfile    "root@${IP}:/tmp/Dockerfile"
+            $SCP -r docs                      "root@${IP}:/tmp/docs"
 
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              deploy/chimney/setup.sh "root@${IP}:/tmp/setup.sh"
-
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              deploy/chimney/Caddyfile "root@${IP}:/tmp/Caddyfile"
-
-            # Copy dashboard files
-            scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              docs "root@${IP}:/tmp/docs"
-
-            # Run setup — pass token via stdin to avoid exposing in process list
-            echo '${{ secrets.PUSH_TOKEN }}' | ssh -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
-              "root@${IP}" 'read -r GITHUB_TOKEN; export GITHUB_TOKEN; ROLE=origin bash /tmp/setup.sh'
+            # Run setup — pass secrets via stdin to avoid exposing in process list
+            printf '%s\n%s\n' \
+              '${{ secrets.PUSH_TOKEN }}' \
+              '${{ secrets.WGMESH_SECRET }}' \
+            | ssh -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$SSH_KEY_FILE" \
+                "root@${IP}" \
+                'read -r GITHUB_TOKEN; read -r WGMESH_SECRET
+                 export GITHUB_TOKEN WGMESH_SECRET
+                 ROLE=origin bash /tmp/setup.sh'
 
             echo "$name deployed successfully"
           done

--- a/deploy/chimney/Caddyfile
+++ b/deploy/chimney/Caddyfile
@@ -1,28 +1,24 @@
-# Caddyfile for chimney edge servers
+# Caddyfile for chimney origin server
 # Caddy handles TLS automatically via Let's Encrypt / ZeroSSL
 #
-# Architecture:
-#   Client → chimney.beerpub.dev → Caddy (TLS termination) → chimney origin (:8080)
+# Architecture (Docker Compose):
+#   Client → chimney.beerpub.dev → Caddy (TLS, ports 80/443)
+#                                 → chimney container (:8080, internal network)
 #
-# Caching is handled by the chimney origin server (in-memory with tiered TTLs),
-# not at the Caddy layer. Caddy acts purely as a TLS-terminating reverse proxy.
+# Caching is handled by the chimney origin server, not at the Caddy layer.
 
 chimney.beerpub.dev {
-	# Reverse proxy to chimney origin server
-	reverse_proxy localhost:8080 {
-		# Health check
+	reverse_proxy chimney:8080 {
 		health_uri /healthz
 		health_interval 10s
 		health_timeout 3s
 	}
 
-	# Response headers
 	header {
 		X-Served-By {system.hostname}
 		-Server
 	}
 
-	# Logging to stdout (captured by systemd journald)
 	log {
 		output stdout
 	}

--- a/deploy/chimney/Dockerfile
+++ b/deploy/chimney/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+# chimney binary is copied in by the deploy workflow (cross-compiled for the target arch)
+COPY chimney /chimney
+COPY docs /docs
+ENTRYPOINT ["/chimney"]

--- a/deploy/chimney/compose.yml
+++ b/deploy/chimney/compose.yml
@@ -1,0 +1,107 @@
+# Docker Compose stack for a chimney origin/edge server.
+#
+# Components:
+#   caddy      — TLS termination, reverse proxy to chimney (ports 80/443)
+#   chimney    — GitHub API proxy + dashboard origin (port 8080, internal only)
+#   dragonfly  — Redis-compatible cache for chimney (port 6379, internal only)
+#   wgmesh     — WireGuard mesh daemon sidecar (host network, NET_ADMIN)
+#
+# Deploy:
+#   docker compose --env-file .env up -d
+#
+# Update chimney binary:
+#   docker compose build chimney && docker compose up -d --no-deps chimney
+#
+# Logs:
+#   docker compose logs -f chimney
+#   docker compose logs -f dragonfly
+
+name: chimney
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  caddy_data:
+  caddy_config:
+  dragonfly_data:
+  wgmesh_state:
+
+services:
+
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    restart: unless-stopped
+    command:
+      - --bind=0.0.0.0
+      - --port=6379
+      - --maxmemory=128mb
+      - --proactor_threads=1
+    volumes:
+      - dragonfly_data:/data
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "redis-cli", "-h", "127.0.0.1", "-p", "6379", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+  chimney:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: chimney:local
+    restart: unless-stopped
+    command:
+      - -addr=:8080
+      - -docs=/docs
+      - -redis=dragonfly:6379
+    environment:
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+    networks:
+      - internal
+    depends_on:
+      dragonfly:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"  # HTTP/3
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - internal
+    depends_on:
+      chimney:
+        condition: service_healthy
+
+  wgmesh:
+    image: ghcr.io/atvirokodosprendimai/wgmesh:latest
+    restart: unless-stopped
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    volumes:
+      - wgmesh_state:/var/lib/wgmesh
+      - /lib/modules:/lib/modules:ro
+    environment:
+      WGMESH_SECRET: ${WGMESH_SECRET:-}
+    command:
+      - join
+      - --secret=${WGMESH_SECRET:-}

--- a/deploy/chimney/setup.sh
+++ b/deploy/chimney/setup.sh
@@ -1,165 +1,82 @@
 #!/usr/bin/env bash
-# setup.sh — Bootstrap a chimney edge/origin server on Ubuntu 24.04
+# setup.sh — Bootstrap a chimney server on Ubuntu 24.04 using Docker Compose.
 #
-# Usage: GITHUB_TOKEN="..." ROLE=origin|edge bash setup.sh
+# Usage: GITHUB_TOKEN="..." WGMESH_SECRET="..." ROLE=origin|edge bash setup.sh
 #
-# The binary should be pre-deployed to /tmp/chimney by the CI workflow.
+# Files expected in /tmp (placed by CI workflow):
+#   /tmp/chimney     — compiled chimney binary (linux/ARCH)
+#   /tmp/docs/       — dashboard static files
+#   /tmp/compose.yml — Docker Compose stack definition
+#   /tmp/Caddyfile   — Caddy reverse proxy config
+#   /tmp/Dockerfile  — Dockerfile for chimney container
+#
 # This script is idempotent — safe to re-run.
+# Cattle, not pets: on failure, reprovision the server rather than debugging state.
 set -euo pipefail
 
 ROLE="${ROLE:-origin}"
-CHIMNEY_USER="chimney"
-CHIMNEY_DIR="/opt/chimney"
+DEPLOY_DIR="/opt/chimney"
 
 echo "=== chimney setup (role=$ROLE) ==="
 
-# ── Validate inputs ──
-if [ -z "${GITHUB_TOKEN:-}" ]; then
-    echo "WARNING: GITHUB_TOKEN not set — chimney will use unauthenticated GitHub API (60 req/hr)"
+# ── Docker ──
+if ! command -v docker &>/dev/null; then
+    echo "Installing Docker..."
+    curl -fsSL https://get.docker.com | sh
+    systemctl enable docker
+    systemctl start docker
+    echo "Docker installed: $(docker --version)"
+else
+    echo "Docker already installed: $(docker --version)"
 fi
 
-# ── System packages ──
-apt-get update -qq
-apt-get install -y -qq caddy curl jq redis-tools
+# ── Deploy directory ──
+mkdir -p "$DEPLOY_DIR/docs"
 
-# ── Create service user (early — required before Dragonfly chown below) ──
-if ! id "$CHIMNEY_USER" &>/dev/null; then
-    useradd --system --home-dir "$CHIMNEY_DIR" --shell /usr/sbin/nologin "$CHIMNEY_USER"
-fi
-mkdir -p "$CHIMNEY_DIR"
-chown "$CHIMNEY_USER:$CHIMNEY_USER" "$CHIMNEY_DIR"
+# ── Copy compose files ──
+cp /tmp/compose.yml  "$DEPLOY_DIR/compose.yml"
+cp /tmp/Caddyfile    "$DEPLOY_DIR/Caddyfile"
+cp /tmp/Dockerfile   "$DEPLOY_DIR/Dockerfile"
 
-# ── Dragonfly (Redis-compatible cache) ──
-# Install Dragonfly as a systemd service for persistent shared caching.
-# Listens on 127.0.0.1:6379 only — not exposed externally.
-if ! command -v dragonfly &>/dev/null; then
-    echo "Installing Dragonfly..."
-    ARCH=$(dpkg --print-architecture)
-    # Dragonfly publishes releases for x86_64 and aarch64
-    if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
-        DF_ARCH="aarch64"
-    else
-        DF_ARCH="x86_64"
-    fi
-    DF_VERSION=$(curl -sf https://api.github.com/repos/dragonflydb/dragonfly/releases/latest | jq -r '.tag_name')
-    DF_URL="https://github.com/dragonflydb/dragonfly/releases/download/${DF_VERSION}/dragonfly-${DF_ARCH}.tar.gz"
-    echo "Downloading Dragonfly ${DF_VERSION} for ${DF_ARCH}..."
-    # The tarball contains "dragonfly-<arch>" binary, not "dragonfly".
-    # Extract to /tmp then rename to get a consistent binary name.
-    curl -sfL "$DF_URL" | tar xz -C /tmp
-    mv "/tmp/dragonfly-${DF_ARCH}" /usr/local/bin/dragonfly
-    chmod +x /usr/local/bin/dragonfly
+if [ -d /tmp/docs ]; then
+    cp -r /tmp/docs/. "$DEPLOY_DIR/docs/"
 fi
 
-# Dragonfly data directory — owned by chimney user so Dragonfly can write it
-mkdir -p /var/lib/dragonfly
-chown "$CHIMNEY_USER:$CHIMNEY_USER" /var/lib/dragonfly
+# ── Copy chimney binary into build context ──
+if [ -f /tmp/chimney ]; then
+    cp /tmp/chimney "$DEPLOY_DIR/chimney"
+    chmod +x "$DEPLOY_DIR/chimney"
+fi
 
-# Dragonfly systemd service
-cat > /etc/systemd/system/dragonfly.service <<EOF
-[Unit]
-Description=Dragonfly — Redis-compatible cache for chimney
-After=network.target
-
-[Service]
-Type=simple
-User=$CHIMNEY_USER
-ExecStart=/usr/local/bin/dragonfly --bind 127.0.0.1 --port 6379 --dbdir /var/lib/dragonfly --maxmemory 128mb --proactor_threads 1
-Restart=always
-RestartSec=3
-
-# Hardening
-NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/var/lib/dragonfly
-PrivateTmp=true
-
-[Install]
-WantedBy=multi-user.target
+# ── Write .env (secrets — never logged) ──
+cat > "$DEPLOY_DIR/.env" <<EOF
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+WGMESH_SECRET=${WGMESH_SECRET:-}
 EOF
+chmod 600 "$DEPLOY_DIR/.env"
 
-systemctl daemon-reload
-systemctl enable dragonfly
-systemctl restart dragonfly
+# ── Build chimney image and start stack ──
+echo "Building chimney image..."
+docker compose -f "$DEPLOY_DIR/compose.yml" --project-directory "$DEPLOY_DIR" build chimney
 
-# Wait for Dragonfly to be ready (up to 30s) before proceeding
-echo "Waiting for Dragonfly on 127.0.0.1:6379..."
-for i in $(seq 1 30); do
-    if redis-cli -h 127.0.0.1 -p 6379 ping 2>/dev/null | grep -q PONG; then
-        echo "Dragonfly ready (attempt $i)"
+echo "Starting stack..."
+docker compose -f "$DEPLOY_DIR/compose.yml" --project-directory "$DEPLOY_DIR" \
+    --env-file "$DEPLOY_DIR/.env" up -d
+
+# ── Wait for chimney to be healthy ──
+echo "Waiting for chimney to be healthy (up to 60s)..."
+for i in $(seq 1 20); do
+    STATUS=$(docker inspect --format='{{.State.Health.Status}}' chimney-chimney-1 2>/dev/null || echo "not_found")
+    if [ "$STATUS" = "healthy" ]; then
+        echo "chimney healthy after $((i * 3))s"
         break
     fi
-    if [ "$i" = "30" ]; then
-        echo "WARNING: Dragonfly not responding after 30s — continuing anyway"
-        journalctl -u dragonfly -n 20 --no-pager || true
+    if [ "$i" = "20" ]; then
+        echo "WARNING: chimney not healthy after 60s (status=$STATUS)"
+        docker compose -f "$DEPLOY_DIR/compose.yml" --project-directory "$DEPLOY_DIR" logs --tail=30
     fi
-    sleep 1
+    sleep 3
 done
 
-# ── Deploy chimney binary ──
-# The binary is expected at /tmp/chimney, placed there by the CI workflow via scp.
-# We do NOT support downloading from arbitrary URLs for security reasons.
-# Stop the running service first to avoid "Text file busy" on the binary.
-systemctl stop chimney 2>/dev/null || true
-
-if [ -f /tmp/chimney ]; then
-    cp /tmp/chimney "$CHIMNEY_DIR/chimney"
-    chmod +x "$CHIMNEY_DIR/chimney"
-else
-    if [ -f "$CHIMNEY_DIR/chimney" ]; then
-        echo "Using existing chimney binary (no new binary in /tmp)"
-    else
-        echo "ERROR: No chimney binary found at /tmp/chimney or $CHIMNEY_DIR/chimney" >&2
-        exit 1
-    fi
-fi
-
-# ── Deploy dashboard files ──
-mkdir -p "$CHIMNEY_DIR/docs"
-if [ -d /tmp/docs ]; then
-    cp -r /tmp/docs/* "$CHIMNEY_DIR/docs/"
-fi
-
-# ── Chimney systemd service ──
-# Note: chimney logs to stdout/stderr, captured by systemd journald.
-# No file-based logging — ProtectSystem=strict is safe without extra ReadWritePaths.
-cat > /etc/systemd/system/chimney.service <<EOF
-[Unit]
-Description=chimney origin server (beerpub.dev dashboard)
-After=network.target dragonfly.service
-Requires=dragonfly.service
-
-[Service]
-Type=simple
-User=$CHIMNEY_USER
-WorkingDirectory=$CHIMNEY_DIR
-ExecStart=$CHIMNEY_DIR/chimney -addr :8080 -docs $CHIMNEY_DIR/docs
-Restart=always
-RestartSec=5
-Environment=GITHUB_TOKEN=${GITHUB_TOKEN:-}
-
-# Hardening
-NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=$CHIMNEY_DIR
-PrivateTmp=true
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-systemctl daemon-reload
-systemctl enable chimney
-systemctl restart chimney
-
-# ── Caddy config ──
-if [ -f /tmp/Caddyfile ]; then
-    cp /tmp/Caddyfile /etc/caddy/Caddyfile
-    systemctl enable caddy
-    systemctl restart caddy
-fi
-
 echo "=== chimney setup complete (role=$ROLE) ==="
-systemctl status chimney --no-pager || true
+docker compose -f "$DEPLOY_DIR/compose.yml" --project-directory "$DEPLOY_DIR" ps


### PR DESCRIPTION
## Summary

Replace bespoke systemd unit management with a Docker Compose stack. Fresh server = `docker compose up`. No accumulated state to debug.

## Stack (`deploy/chimney/compose.yml`)

| Service | Image | Notes |
|---------|-------|-------|
| `dragonfly` | `dragonflydb/dragonfly:latest` | Official image, healthchecked |
| `chimney` | Built `FROM scratch` | Cross-compiled binary, internal only |
| `caddy` | `caddy:2-alpine` | TLS termination on 80/443 |
| `wgmesh` | `ghcr.io/.../wgmesh:latest` | Host network sidecar, NET_ADMIN |

## Why this fixes Dragonfly

The previous systemd approach had three races (user ordering, no User= directive, no readiness check). With Compose:

- `depends_on: dragonfly: condition: service_healthy` — chimney container doesn't start until dragonfly passes its healthcheck (`redis-cli ping`)
- No user/ownership issues — the container handles its own uid
- No timing races — Compose waits for actual readiness, not just process start

## Changes

- `deploy/chimney/Dockerfile` — minimal `FROM scratch` image for chimney binary
- `deploy/chimney/compose.yml` — full stack with healthchecks and correct ordering
- `deploy/chimney/Caddyfile` — `reverse_proxy chimney:8080` (DNS service name, not localhost)
- `deploy/chimney/setup.sh` — simplified: install Docker, copy files, `docker compose up`
- `chimney-deploy.yml` — copies compose.yml + Dockerfile, passes WGMESH_SECRET
- `chimney-provision.yml` — same additions

## After merge

Trigger **Chimney Provision → rebuild** (cattle) then **Chimney Deploy** for a clean server with the compose stack. `/healthz` should show `"dragonfly":"connected"` on first boot.