### PR TITLE
fix: improve dragonfly container startup reliability on arm64

### DIFF
--- a/deploy/chimney/compose.yml
+++ b/deploy/chimney/compose.yml
@@ -33,21 +33,25 @@ services:
   dragonfly:
     image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
     restart: unless-stopped
+    ulimits:
+      memlock: -1
     command:
       - --bind=0.0.0.0
       - --port=6379
       - --maxmemory=128mb
-      - --proactor_threads=1
+      - --proactor_threads=2
+      - --no_tls
     volumes:
       - dragonfly_data:/data
     networks:
       - internal
     healthcheck:
-      test: ["CMD", "redis-cli", "-h", "127.0.0.1", "-p", "6379", "ping"]
+      # DragonflyDB image ships redis-cli at /usr/local/bin/redis-cli
+      test: ["CMD-SHELL", "redis-cli -h 127.0.0.1 -p 6379 ping | grep -q PONG"]
       interval: 5s
       timeout: 3s
-      retries: 10
-      start_period: 10s
+      retries: 12
+      start_period: 20s
 
   chimney:
     build:


### PR DESCRIPTION
## Problem

Dragonfly container starts and immediately exits as unhealthy on chimney-nbg1 (arm64/cax11). The container crashed before the healthcheck even ran, indicating a startup failure.

## Fix

- Add `ulimits.memlock: -1` — DragonflyDB requires unlimited locked memory for mmap/io_uring operations. Without this, it exits immediately on some kernels.
- Add `--no_tls` flag to suppress TLS initialization (unnecessary overhead for internal-only service).
- Bump `--proactor_threads` to 2 (cax11 has 2 vCPUs; using 1 was under-utilizing).
- Log dragonfly container state + logs in setup.sh if compose fails, for easier debugging.