### PR TITLE
fix: disable io_uring in dragonfly, use epoll mode for arm64 compat

### DIFF
--- a/deploy/chimney/compose.yml
+++ b/deploy/chimney/compose.yml
@@ -41,6 +41,10 @@ services:
       - --maxmemory=128mb
       - --proactor_threads=2
       - --no_tls
+      # Disable io_uring: Hetzner cax11 (arm64) kernels may lack required
+      # uring_cmd support. epoll mode is universally compatible.
+      - --proactor_mode=epoll
+      - --alsologtostderr
     volumes:
       - dragonfly_data:/data
     networks:

--- a/deploy/chimney/setup.sh
+++ b/deploy/chimney/setup.sh
@@ -62,8 +62,11 @@ docker compose -f "$DEPLOY_DIR/compose.yml" --project-directory "$DEPLOY_DIR" bu
 echo "Starting stack..."
 if ! docker compose -f "$DEPLOY_DIR/compose.yml" --project-directory "$DEPLOY_DIR" \
     --env-file "$DEPLOY_DIR/.env" up -d 2>&1; then
-    echo "ERROR: docker compose up failed — dumping dragonfly logs:"
-    docker logs chimney-dragonfly-1 2>&1 | tail -50 || true
+    echo "ERROR: docker compose up failed — waiting 3s then dumping diagnostics:"
+    sleep 3
+    echo "--- dragonfly logs ---"
+    docker logs chimney-dragonfly-1 2>&1 | tail -80 || true
+    echo "--- dragonfly inspect ---"
     docker inspect chimney-dragonfly-1 2>&1 | python3 -c "
 import sys, json
 try:
@@ -76,6 +79,8 @@ try:
 except Exception as e:
     print('Could not parse:', e)
 " || true
+    echo "--- uname/kernel ---"
+    uname -a || true
     exit 1
 fi
 


### PR DESCRIPTION
## Problem

DragonflyDB container crashes silently on Hetzner cax11 (arm64) with container state `restarting`, no log output. The container starts and exits in <500ms, which is consistent with an io_uring initialization failure at startup.

## Root Cause

Dragonfly's default proactor uses io_uring (specifically `uring_cmd`). Hetzner cax11 arm64 VMs run a kernel that may lack the `uring_cmd` capability required by DragonflyDB's io_uring mode.

## Fix

Add `--proactor_mode=epoll` flag which forces Dragonfly to use epoll instead of io_uring — universally compatible with all Linux kernels.

Also adds `--alsologtostderr` for visible crash logs and improved setup.sh diagnostics on compose failure.