### PR TITLE
fix: use busybox base for chimney image to enable healthcheck

### DIFF
--- a/deploy/chimney/Dockerfile
+++ b/deploy/chimney/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM busybox:musl
 # chimney binary is copied in by the deploy workflow (cross-compiled for the target arch)
 COPY chimney /chimney
 COPY docs /docs

--- a/deploy/chimney/setup.sh
+++ b/deploy/chimney/setup.sh
@@ -88,6 +88,28 @@ try:
 except Exception as e:
     print('Could not parse:', e)
 " || true
+    echo "--- chimney logs ---"
+    docker logs chimney-chimney-1 2>&1 | tail -80 || true
+    echo "--- chimney inspect ---"
+    docker inspect chimney-chimney-1 2>&1 | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)[0]
+    state = d.get('State', {})
+    print('Container state:', state.get('Status'))
+    print('Exit code:', state.get('ExitCode'))
+    print('Error:', state.get('Error'))
+    print('OOMKilled:', state.get('OOMKilled'))
+    hc = state.get('Health', {})
+    if hc:
+        print('Health status:', hc.get('Status'))
+        for log in (hc.get('Log') or [])[-3:]:
+            print('  HC output:', log.get('Output', '').strip())
+except Exception as e:
+    print('Could not parse:', e)
+" || true
+    echo "--- caddy logs ---"
+    docker logs chimney-caddy-1 2>&1 | tail -20 || true
     exit 1
 fi
 


### PR DESCRIPTION
## Problem

The chimney container was always failing its Docker health check:
```
dependency failed to start: container chimney-chimney-1 is unhealthy
```

Root cause: `FROM scratch` has no shell (`/bin/sh`) and no `wget`. The `CMD-SHELL` healthcheck form requires a shell to execute, so it always fails with exec format error.

## Fix

- Change base image from `scratch` to `busybox:musl` (~1.4MB), which includes a static `wget` 
- The chimney binary is compiled with `CGO_ENABLED=0` so it's a fully static binary compatible with any Linux environment
- Also add chimney and caddy log output to setup.sh diagnostics for future debugging

## Impact

The chimney healthcheck `wget -qO- http://localhost:8080/healthz || exit 1` will now work correctly.