### PR TITLE
chore: initialise eidos project structure

### DIFF
--- a/.eidos-config.yaml
+++ b/.eidos-config.yaml
@@ -1,0 +1,6 @@
+git_workflow: true
+status_reporting: true
+skills_list: true
+specs_and_concepts: true
+session_context: true
+context_tracking_max: 200000

--- a/eidos/seed.md
+++ b/eidos/seed.md
@@ -1,0 +1,27 @@
+# This is the seed for your specifications
+
+The main idea:
+- You can create code from intent (prompts)
+- You can extract intent from code (=>docs)
+- Eidos helps you keep intent (spec docs) and manifestation (code) in sync
+- Eidos lets you work more on the intent layer (edit specs)
+
+Run `/eidos:help` for more info.
+
+## New Projects
+
+Replace the content of this file with all your project relevant notes.
+Then tell claude to run `/eidos:spec` on it.
+Take a look at the generated files.
+And leave inline comments using `{{double curly braces}}`.
+Just write casually on what should be changed, or what general thoughts you have.
+Then run `/eidos:refine` to have the ai process and group them.
+It may ask you more questions, which you can answer.
+You may end up creating a `/eidos:plan` to start making larger spec edits, or start to implement things.
+You can also use `/eidos:reference` to write docs on knowledge that is relevant to your project, but not in its control.
+
+## Existing Projects
+
+If you have any notes you want to incorporate, see the point above.
+Otherwise try out `/eidos:pull` to extract a base specification from your existing code.
+Read it through, and then either edit directly or leave `{{comments}}` to `/eidos:refine` with LLM support.

--- a/memory/human.md
+++ b/memory/human.md
@@ -1,0 +1,28 @@
+
+# fleeting notes
+this file is for fleeting notes.
+the ai will not mess with these files.
+you don't have to worry about clean specs or anything.
+just dump stuff here as needed.
+
+# use scratchpad
+the scratchpad section below is meant as an area to compose messages to be pasted into the claude session.
+this way you get the normal editing behaviour of markdown.
+and you also don't have to worry about your message being lost after accidentally hitting arrow+up one time too often.
+
+# write some specs
+to get started with spec driven development,
+see seed.md or run /eidos:help
+
+# remove default notes
+wait i didnt write these notes, i should remove them
+
+
+________________________________________
+TEMP
+
+
+________________________________________
+SCRATCHPAD LEAVE AT BOTTOM
+
+


### PR DESCRIPTION
## Summary

- Adds `eidos/` folder with `seed.md` for spec-driven development
- Adds `memory/` folder with `human.md` scratchpad
- Adds `.eidos-config.yaml` with default eidos settings

## Test plan

- [ ] Verify `eidos/seed.md`, `memory/human.md`, and `.eidos-config.yaml` are present and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)