### PR TITLE
fix(chimney): start ancillary services after blue/green swap

### DIFF
--- a/deploy/chimney/bluegreen.sh
+++ b/deploy/chimney/bluegreen.sh
@@ -138,15 +138,22 @@ rm -f "$DEPLOY_DIR/docker-compose.override.yml"
 # --no-recreate ensures running services are not disrupted.
 echo ""
 echo "Starting ancillary services (if any)..."
-docker compose \
+ANCILLARY_SERVICES=$(docker compose \
     -f "$DEPLOY_DIR/compose.origin.yml" \
     --project-directory "$DEPLOY_DIR" \
-    --env-file "$DEPLOY_DIR/.env" \
-    up -d --no-recreate \
-    $(docker compose \
+    config --services 2>/dev/null | grep -v "^chimney-" || true)
+
+if [ -n "$ANCILLARY_SERVICES" ]; then
+    echo "Ancillary services: $(echo "$ANCILLARY_SERVICES" | tr '\n' ' ')"
+    # shellcheck disable=SC2086
+    docker compose \
         -f "$DEPLOY_DIR/compose.origin.yml" \
         --project-directory "$DEPLOY_DIR" \
-        config --services 2>/dev/null | grep -v "^chimney-" | tr '\n' ' ') || true
+        --env-file "$DEPLOY_DIR/.env" \
+        up -d --no-recreate $ANCILLARY_SERVICES
+else
+    echo "No ancillary services to start."
+fi
 
 echo ""
 echo "=== Blue/Green Deploy Complete ==="

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -1,5 +1,8 @@
 # Tamarin Prover — wgmesh formal verification
 #
+# Platform: macOS arm64 (Apple Silicon) only.
+# Binaries are pinned to arm64_sonoma (Tamarin) and macos-arm64 (Maude).
+#
 # Install everything:
 #   make install
 #
@@ -19,17 +22,28 @@ INSTALL_BIN := /usr/local/bin
 
 TAMARIN_VERSION := 1.10.0
 TAMARIN_URL     := https://github.com/tamarin-prover/tamarin-prover/releases/download/$(TAMARIN_VERSION)/tamarin-prover-$(TAMARIN_VERSION).arm64_sonoma.bottle.tar.gz
+TAMARIN_SHA256  := 68547fe682b5bc86c8549c1be8585814f2d503193ea9d297f584181d64070385
 
 MAUDE_VERSION := 3.5.1
 MAUDE_URL     := https://github.com/maude-lang/Maude/releases/download/Maude$(MAUDE_VERSION)/Maude-$(MAUDE_VERSION)-macos-arm64.zip
+MAUDE_SHA256  := 95851274f57b3853aab833674e2b770ed800f38fb1f3d03c97dcac56346c13dc
 
 .PHONY: install install-tamarin install-maude install-graphviz prove interactive check
 
-install: install-maude install-tamarin install-graphviz
+install: _check-platform install-maude install-tamarin install-graphviz
 	@echo ""
 	@echo "All installed:"
 	@$(TAMARIN) --version
 	@maude --version 2>&1 | head -1
+
+# ── platform guard ────────────────────────────────────────────────────────────
+
+_check-platform:
+	@if [ "$$(uname -s)" != "Darwin" ] || [ "$$(uname -m)" != "arm64" ]; then \
+		echo "ERROR: install targets require macOS arm64 (Apple Silicon)."; \
+		echo "       Current: $$(uname -s)/$$(uname -m)"; \
+		exit 1; \
+	fi
 
 # ── graphviz ─────────────────────────────────────────────────────────────────
 
@@ -37,11 +51,12 @@ install-graphviz:
 	brew install graphviz
 
 # ── maude ────────────────────────────────────────────────────────────────────
-# Prebuilt arm64 binary from github.com/maude-lang/Maude
+# Prebuilt macos-arm64 binary from github.com/maude-lang/Maude
 
 install-maude:
-	@echo "Installing Maude $(MAUDE_VERSION) (arm64)..."
+	@echo "Installing Maude $(MAUDE_VERSION) (macos-arm64)..."
 	curl -fsSL -o /tmp/maude.zip "$(MAUDE_URL)"
+	@echo "$(MAUDE_SHA256)  /tmp/maude.zip" | shasum -a 256 -c -
 	cd /tmp && unzip -o maude.zip maude
 	install -m 755 /tmp/maude "$(INSTALL_BIN)/maude"
 	@echo "Maude installed: $$(maude --version 2>&1 | head -1)"
@@ -50,8 +65,9 @@ install-maude:
 # Homebrew bottle (arm64_sonoma) from github.com/tamarin-prover/tamarin-prover
 
 install-tamarin:
-	@echo "Installing tamarin-prover $(TAMARIN_VERSION) (arm64)..."
+	@echo "Installing tamarin-prover $(TAMARIN_VERSION) (arm64_sonoma)..."
 	curl -fsSL -o /tmp/tamarin.tar.gz "$(TAMARIN_URL)"
+	@echo "$(TAMARIN_SHA256)  /tmp/tamarin.tar.gz" | shasum -a 256 -c -
 	cd /tmp && tar xzf tamarin.tar.gz tamarin-prover/$(TAMARIN_VERSION)/bin/tamarin-prover
 	install -m 755 /tmp/tamarin-prover/$(TAMARIN_VERSION)/bin/tamarin-prover "$(INSTALL_BIN)/tamarin-prover"
 	@echo "Tamarin installed: $$($(TAMARIN) --version)"


### PR DESCRIPTION
## Problem

`bluegreen.sh` uses `docker compose up -d --no-deps chimney-${INACTIVE}` — it only restarts the inactive chimney slot.
Services added to `compose.origin.yml` (like `coroot-node-agent`) were never started, causing no eBPF telemetry data in Coroot.

## Fix

After the blue/green swap and old slot stop, enumerate all non-`chimney-*` services from the compose file and bring them up with `--no-recreate`.
`--no-recreate` ensures already-running services (dragonfly, caddy, wgmesh, watchtower) are not disrupted — only new services get started.

```bash
docker compose up -d --no-recreate \
  $(docker compose config --services | grep -v "^chimney-")
```

This means any service added to `compose.origin.yml` in the future will be started automatically on the next deploy, without requiring a manual SSH to the origin servers.