### PR TITLE
ops(chimney): smoke tests run unconditionally on every deploy

### DIFF
--- a/.github/workflows/chimney-deploy.yml
+++ b/.github/workflows/chimney-deploy.yml
@@ -132,7 +132,6 @@ jobs:
           sleep 60
 
       - name: Smoke tests
-        if: steps.origins.outputs.found == 'true'
         run: |
           set -euo pipefail
           echo "## Smoke Tests" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The smoke tests step had `if: steps.origins.outputs.found == 'true'`.
If Hetzner label discovery returned no servers, the tests were silently skipped and the deploy job exited 0 — no verification that `chimney.beerpub.dev` actually works.

## Fix

Remove the condition. Smoke tests always run.

The tests hit `chimney.beerpub.dev` (the edge), not origin servers directly, so they work regardless of whether a blue/green deploy just happened. This also means the tests act as a continuous health check on the edge routing layer.