### PR TITLE
chore: one-shot copy secrets to tvcentras

### DIFF
--- a/.github/workflows/copy-secrets-tvcentras.yml
+++ b/.github/workflows/copy-secrets-tvcentras.yml
@@ -1,0 +1,21 @@
+name: Copy secrets to tvcentras (one-shot)
+on:
+  workflow_dispatch:
+jobs:
+  copy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copy secrets
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          WGMESH_SECRET: ${{ secrets.WGMESH_SECRET }}
+          CHIMNEY_SSH_KEY: ${{ secrets.CHIMNEY_SSH_KEY }}
+          CHIMNEY_SSH_PUBKEY: ${{ secrets.CHIMNEY_SSH_PUBKEY }}
+        run: |
+          REPO="atvirokodosprendimai/tvcentras"
+          printf '%s' "$HCLOUD_TOKEN"     | gh secret set HCLOUD_TOKEN     --repo "$REPO"
+          printf '%s' "$WGMESH_SECRET"   | gh secret set WGMESH_SECRET   --repo "$REPO"
+          printf '%s' "$CHIMNEY_SSH_KEY" | gh secret set CHIMNEY_SSH_KEY --repo "$REPO"
+          printf '%s' "$CHIMNEY_SSH_PUBKEY" | gh secret set CHIMNEY_SSH_PUBKEY --repo "$REPO"
+          echo "Secrets copied to $REPO"


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` workflow to copy infra secrets to the `tvcentras` repo
- Secrets copied: `HCLOUD_TOKEN`, `WGMESH_SECRET`, `CHIMNEY_SSH_KEY`, `CHIMNEY_SSH_PUBKEY`
- This is needed so `tvcentras/provision.yml` can spin up the origin server and join wgmesh

## Steps after merge
1. Go to wgmesh → Actions → **Copy secrets to tvcentras (one-shot)** → Run workflow
2. Verify secrets appear in [tvcentras settings](https://github.com/atvirokodosprendimai/tvcentras/settings/secrets/actions)
3. Delete `copy-secrets-tvcentras.yml` (follow-up PR or direct commit)
4. Go to tvcentras → Actions → **Provision tvcentras origin** → Run workflow (action: provision)

## Test plan
- [ ] Run the workflow manually after merge
- [ ] Confirm all 4 secrets visible in tvcentras repo secrets page

🤖 Generated with [Claude Code](https://claude.com/claude-code)