### PR TITLE
spec: Issue #345 - Create Falsification Test for Spec Validation Pipeline

### DIFF
--- a/specs/issue-345-spec.md
+++ b/specs/issue-345-spec.md
@@ -1,0 +1,70 @@
+# Spec: Issue #345 - Create Falsification Test for Spec Validation Pipeline
+
+## Classification
+
+**Infrastructure** — Add verification test to detect when spec validation pipeline is broken.
+
+## Problem Analysis
+
+### Current State
+- Valid spec PRs are failing validation
+- We assume "pipeline is broken" but haven't proven it
+- No way to detect when pipeline works vs broken
+
+### Karl Popper Approach
+Instead of assuming pipeline is broken, we create a test that **falsifies** this assumption:
+
+**Test**: Create a known-good spec PR that SHOULD pass validation
+- If it passes → assumption "pipeline is broken" is FALSE (pipeline works)
+- If it fails → assumption "pipeline is broken" is TRUE (pipeline broken confirmed)
+
+This is falsification, not verification.
+
+## Proposed Approach
+
+### Layer 1: Create Known-Good Test Spec
+
+Create a minimal valid spec that should always pass:
+
+```markdown
+# Spec: Issue #999 - Test Spec
+
+## Classification
+**Test** — Smoke test for validation pipeline.
+
+## Problem Analysis
+This is a test spec to verify validation works.
+
+## Proposed Approach
+Testing validation.
+```
+
+### Layer 2: Run Validation on Test Spec
+
+1. Create issue #999
+2. Add minimal valid spec to PR
+3. Run validation
+4. If passes → pipeline OK
+5. If fails → pipeline broken (confirmed)
+
+### Layer 3: Monitoring
+
+- Run test periodically (weekly)
+- Alert if test fails
+- This provides ongoing falsification of "pipeline is broken"
+
+## Test Strategy
+
+1. Create test spec with all required sections
+2. Verify it passes validation
+3. If it fails → pipeline broken (actionable)
+4. Schedule weekly run
+
+## Affected Files
+
+- `specs/issue-999-test-spec.md` — NEW: Test spec
+- (No changes to workflow - just test)
+
+## Estimated Complexity
+
+**Low** — Create test spec, verify it passes.


### PR DESCRIPTION
## Karl Popper Approach

Instead of assuming pipeline is broken, create a test that **falsifies** this assumption:

1. Create a known-good spec that SHOULD pass validation
2. Run validation on it
3. If passes → pipeline works (assumption "pipeline is broken" is FALSE)
4. If fails → pipeline broken confirmed (assumption TRUE)

This is falsification, not verification.