### PR TITLE
fix(goose-build): skip PR creation when no code changes

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -351,6 +351,7 @@ jobs:
           fi
 
       - name: Commit and push
+        id: commit
         if: steps.validate.outputs.has_changes == 'true'
         env:
           ISSUE_NUM: ${{ steps.spec.outputs.issue_number }}
@@ -376,9 +377,16 @@ jobs:
 
           git push origin "$IMPL_BRANCH"
 
+          # Check if branch actually has commits ahead of main
+          AHEAD=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)
+          echo "commits_ahead=$AHEAD" >> "$GITHUB_OUTPUT"
+          if [ "$AHEAD" -eq 0 ]; then
+            echo "::warning::Branch pushed but has no commits ahead of main"
+          fi
+
       # ── Create implementation PR ───────────────────────
       - name: Create implementation PR
-        if: steps.validate.outputs.has_changes == 'true'
+        if: steps.validate.outputs.has_changes == 'true' && steps.commit.outputs.commits_ahead != '0'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -447,7 +455,7 @@ jobs:
             });
 
       - name: Report no changes
-        if: steps.validate.outputs.has_changes == 'false'
+        if: steps.validate.outputs.has_changes == 'false' || steps.commit.outputs.commits_ahead == '0'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Goose may run successfully but produce no code changes (e.g. spec too large, classified as wont-do)
- Previously this caused "No commits between main and goose/issue-X" error in PR creation
- Now checks `commits_ahead` after push and skips PR creation if 0
- Reports "no changes" instead of failing

**Root cause:** Run 22546665030 — Goose ran fine but produced no diff for the Zero-Trust spec.

## Test plan

- [ ] Re-trigger with a smaller, implementable spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)