### PR TITLE
fix(auto-merge): use PUSH_TOKEN for goose-review dispatch

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Auto-approve and merge eligible PRs
         uses: actions/github-script@v7
+        env:
+          PUSH_TOKEN: ${{ secrets.PUSH_TOKEN }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -228,16 +230,27 @@ jobs:
 
                   core.info(`PR #${prNumber}: ${unresolvedThreads.length} unresolved thread(s) from ${byAuthor.join(', ')}`);
 
-                  // Dispatch goose-review to address Copilot feedback on the PR branch
+                  // Dispatch goose-review to address Copilot feedback on the PR branch.
+                  // Uses PUSH_TOKEN (PAT) because the GitHub App lacks actions:write permission.
                   if (copilotThreads.length > 0) {
                     try {
-                      await github.rest.actions.createWorkflowDispatch({
-                        owner, repo,
-                        workflow_id: 'goose-review.yml',
-                        ref: 'main',
-                        inputs: { pr_number: String(prNumber) },
-                      });
-                      core.info(`PR #${prNumber}: dispatched goose-review to address ${copilotThreads.length} Copilot thread(s)`);
+                      const resp = await fetch(
+                        `https://api.github.com/repos/${owner}/${repo}/actions/workflows/goose-review.yml/dispatches`,
+                        {
+                          method: 'POST',
+                          headers: {
+                            'Authorization': `Bearer ${process.env.PUSH_TOKEN}`,
+                            'Accept': 'application/vnd.github+json',
+                            'Content-Type': 'application/json',
+                          },
+                          body: JSON.stringify({ ref: 'main', inputs: { pr_number: String(prNumber) } }),
+                        }
+                      );
+                      if (resp.ok || resp.status === 204) {
+                        core.info(`PR #${prNumber}: dispatched goose-review to address ${copilotThreads.length} Copilot thread(s)`);
+                      } else {
+                        core.warning(`PR #${prNumber}: goose-review dispatch failed: ${resp.status} ${await resp.text()}`);
+                      }
                     } catch (dispatchErr) {
                       core.warning(`PR #${prNumber}: could not dispatch goose-review: ${dispatchErr.message}`);
                     }


### PR DESCRIPTION
## Summary
The GitHub App (wgmesh-bot) lacks `actions:write` permission, causing goose-review workflow dispatch to fail with "Resource not accessible by integration".

Uses `PUSH_TOKEN` (PAT) via `fetch` for the dispatch call while keeping the App token for all other operations.

## Context
Discovered while testing goose-review on PR #378 — auto-merge correctly detected 4 unresolved Copilot threads but couldn't dispatch goose-review.

## Test plan
- [ ] Merge this PR
- [ ] Trigger auto-merge on PR #378 (which has 4 unresolved Copilot threads)
- [ ] Verify goose-review is dispatched successfully
- [ ] Verify goose-review addresses the comments and pushes a fix