### PR TITLE
fix(goose-review): fix recipe YAML parsing and improve error reporting

### DIFF
--- a/.github/goose-recipes/wgmesh-review.yaml
+++ b/.github/goose-recipes/wgmesh-review.yaml
@@ -20,15 +20,8 @@ instructions: |
   - Lint: `go vet ./...`
 
 prompt: |
-  Address the review feedback below. Read each comment, make the minimal fix, then verify with build/test/vet.
-
-  {{ review_feedback }}
-
-parameters:
-  - key: review_feedback
-    input_type: file
-    requirement: required
-    description: "Path to file containing structured review feedback from PR threads"
+  Address the review feedback in the file /tmp/review-feedback.txt.
+  Read the file first, then for each comment make the minimal fix and verify with build/test/vet.
 
 extensions:
   - type: builtin

--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -150,23 +150,28 @@ jobs:
           go-version: "1.25"
 
       - name: Run Goose review with recipe
+        id: goose
         if: steps.pr.outputs.skip != 'true'
         env:
           GOOSE_DISABLE_SESSION_NAMING: "true"
           GOOSE_MODE: "auto"
           REVIEW_FEEDBACK: ${{ steps.pr.outputs.feedback }}
         run: |
-          # Write feedback to file to avoid shell quoting issues with --params
+          # Write feedback to file — Goose reads it directly (not via template substitution)
           printf '%s\n' "$REVIEW_FEEDBACK" > /tmp/review-feedback.txt
 
-          goose run \
+          if goose run \
             --recipe .github/goose-recipes/wgmesh-review.yaml \
-            --params "review_feedback=/tmp/review-feedback.txt" \
             --no-session \
-            2>&1 | tee /tmp/goose-review-output.log
+            2>&1 | tee /tmp/goose-review-output.log; then
+            echo "goose_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "goose_ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Goose exited with non-zero status"
+          fi
 
       - name: Commit and push changes
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.pr.outputs.skip != 'true' && steps.goose.outputs.goose_ok == 'true'
         env:
           PR_NUM: ${{ github.event.inputs.pr_number }}
           PR_BRANCH: ${{ steps.pr.outputs.branch }}
@@ -186,9 +191,13 @@ jobs:
           github-token: ${{ secrets.PUSH_TOKEN }}
           script: |
             const prNumber = parseInt('${{ github.event.inputs.pr_number }}', 10);
+            const gooseOk = '${{ steps.goose.outputs.goose_ok }}' === 'true';
+            const body = gooseOk
+              ? '**Goose review pass complete.** Changes pushed to address reviewer comments.'
+              : '**Goose review failed.** Could not process review comments — manual attention needed.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              body: '**Goose review pass complete.** Changes pushed to address reviewer comments.'
+              body,
             });


### PR DESCRIPTION
## Summary
Goose review was silently failing because Copilot review comments (containing `${}`, backticks, code blocks) were template-substituted into the recipe YAML, breaking YAML parsing.

**Fixes:**
1. Recipe reads `/tmp/review-feedback.txt` directly instead of `{{ review_feedback }}` template
2. Workflow tracks Goose exit status — only commits on success
3. PR comment reflects actual outcome (success vs failure)

## Context
Discovered while testing goose-review on PR #378. Run 22555316196 showed:
```
Error: Invalid recipe: found character that cannot start any token
```
Then posted "Goose review pass complete" despite making zero changes.

## Test plan
- [ ] Merge this PR
- [ ] Re-dispatch goose-review on PR #378
- [ ] Verify Goose actually processes the review comments