### PR TITLE
fix(goose-review): don't cancel in-progress runs

### DIFF
--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 30
     concurrency:
       group: goose-review-${{ github.event.inputs.pr_number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     steps:
       - name: Validate API key


### PR DESCRIPTION
## Summary

Auto-merge cron fires every 10 minutes and re-dispatches goose-review for PR #378. With `cancel-in-progress: true`, each new dispatch kills the previous Goose run before it can finish (Goose needs ~15-20 min). Three consecutive runs were cancelled this way.

Change to `cancel-in-progress: false` so the first run completes and subsequent dispatches queue.

## Test plan
- [ ] Admin-merge, then trigger goose-review on #378
- [ ] Verify run isn't cancelled by the next auto-merge cycle
- [ ] Verify Goose completes and posts accurate PR comment