### PR TITLE
fix(goose-review): increase job timeout from 30 to 60 minutes

### DIFF
--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   review:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     concurrency:
       group: goose-review-${{ github.event.inputs.pr_number }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

Goose ran for 29m53s processing 4 Copilot review comments on PR #378, then got killed by the 30-minute job timeout. GitHub shows this as `conclusion: cancelled`, which was misleading — we thought it was concurrency cancellation.

Increase to 60 minutes to give Goose enough time.

## Evidence

Run 22570742886 job timing:
- Started: `09:58:16Z`
- Cancelled: `10:28:09Z` (exactly 30 min)
- Step killed: "Run Goose review with recipe"