### PR TITLE
fix(goose): switch from Google/Gemini to OpenRouter/Claude

### DIFF
--- a/.github/goose-recipes/wgmesh-implementation.yaml
+++ b/.github/goose-recipes/wgmesh-implementation.yaml
@@ -64,8 +64,8 @@ extensions:
     name: developer
 
 settings:
-  goose_provider: "google"
-  goose_model: "gemini-2.5-flash"
+  goose_provider: "openrouter"
+  goose_model: "anthropic/claude-sonnet-4"
   max_turns: 50
 
 retry:

--- a/.github/goose-recipes/wgmesh-review.yaml
+++ b/.github/goose-recipes/wgmesh-review.yaml
@@ -28,8 +28,8 @@ extensions:
     name: developer
 
 settings:
-  goose_provider: "google"
-  goose_model: "gemini-2.5-flash"
+  goose_provider: "openrouter"
+  goose_model: "anthropic/claude-sonnet-4"
   max_turns: 30
 
 retry:

--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -16,7 +16,7 @@ permissions:
   pull-requests: write
 
 env:
-  GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+  OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
 jobs:
   review:
@@ -29,10 +29,10 @@ jobs:
     steps:
       - name: Validate API key
         env:
-          KEY: ${{ secrets.GOOGLE_API_KEY }}
+          KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           if [ -z "$KEY" ]; then
-            echo "::error::GOOGLE_API_KEY secret is not configured."
+            echo "::error::OPENROUTER_API_KEY secret is not configured."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Goose was configured for `google`/`gemini-2.5-flash` but the `GOOGLE_API_KEY` is invalid. Goose hit `API Key not found (400)` and hung for the entire 60-minute timeout doing nothing.

Switch to `openrouter`/`anthropic/claude-sonnet-4`, using the `OPENROUTER_API_KEY` secret that's already configured and working (used by company-loop).

## Changes
- `wgmesh-review.yaml`: `openrouter` + `anthropic/claude-sonnet-4`
- `wgmesh-implementation.yaml`: `openrouter` + `anthropic/claude-sonnet-4`
- `goose-review.yml`: `OPENROUTER_API_KEY` env + validation

## Test plan
- [ ] Admin-merge, cancel running goose-review, dispatch fresh
- [ ] Verify Goose starts and connects to OpenRouter
- [ ] Verify Goose processes review comments and pushes fixes