### PR TITLE
fix(goose-review): add 45min timeout to prevent Goose hang

### DIFF
--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -172,14 +172,24 @@ jobs:
           # Write feedback to file — Goose reads it directly (not via template substitution)
           printf '%s\n' "$REVIEW_FEEDBACK" > /tmp/review-feedback.txt
 
-          if goose run \
+          # Goose sometimes hangs after completing work (doesn't exit despite --no-session).
+          # Use timeout to kill it after 45 min — the job timeout is 60 min, leaving 15 min
+          # for the commit/push/comment steps. Exit code 124 = timeout (treat as success if
+          # Goose made changes, since it completed work but just didn't exit).
+          exit_code=0
+          timeout 2700 goose run \
             --recipe .github/goose-recipes/wgmesh-review.yaml \
             --no-session \
-            2>&1 | tee /tmp/goose-review-output.log; then
+            2>&1 | tee /tmp/goose-review-output.log || exit_code=$?
+
+          if [ "$exit_code" -eq 0 ] || [ "$exit_code" -eq 124 ]; then
             echo "goose_ok=true" >> "$GITHUB_OUTPUT"
+            if [ "$exit_code" -eq 124 ]; then
+              echo "::warning::Goose timed out (likely hung after completing work)"
+            fi
           else
             echo "goose_ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Goose exited with non-zero status"
+            echo "::warning::Goose exited with status $exit_code"
           fi
 
       - name: Commit and push changes


### PR DESCRIPTION
## Summary

Goose completes its review work in ~3 minutes (edits files, runs build/test/vet, commits locally) but then **hangs indefinitely** instead of exiting. The process sits idle until the 60-min job timeout kills everything, and the "Commit and push" step never runs — all Goose's changes are lost.

Evidence from run 22580109077:
- `14:21:26Z` — Goose starts
- `14:24:09Z` — Goose commits changes locally (3 min of actual work)
- `15:21:44Z` — Job timeout kills Goose (57 min of idle hanging)
- Commit/push step never executed

Fix: wrap `goose run` with `timeout 2700` (45 min). Exit code 124 (timeout) is treated as success, allowing the commit/push step to run with the 15 min remaining.

## Test plan
- [ ] Admin-merge, dispatch goose-review on #378
- [ ] Verify Goose completes work then gets killed by timeout
- [ ] Verify commit/push step runs and pushes Goose's changes
- [ ] Verify PR comment accurately reflects outcome