### PR TITLE
feat(goose-review): provider cascade — OpenRouter then Anthropic

### DIFF
--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -17,6 +17,7 @@ permissions:
 
 env:
   OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
 jobs:
   review:
@@ -27,12 +28,13 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - name: Validate API key
-        env:
-          KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      - name: Validate API keys
         run: |
-          if [ -z "$KEY" ]; then
-            echo "::error::OPENROUTER_API_KEY secret is not configured."
+          has_key=false
+          [ -n "$OPENROUTER_API_KEY" ] && has_key=true && echo "OpenRouter API key: configured"
+          [ -n "$ANTHROPIC_API_KEY" ] && has_key=true && echo "Anthropic API key: configured"
+          if [ "$has_key" = false ]; then
+            echo "::error::No LLM API keys configured (need OPENROUTER_API_KEY or ANTHROPIC_API_KEY)"
             exit 1
           fi
 
@@ -164,7 +166,7 @@ jobs:
         if: steps.pr.outputs.skip != 'true'
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Run Goose review with recipe
+      - name: Run Goose review with provider cascade
         id: goose
         if: steps.pr.outputs.skip != 'true'
         env:
@@ -177,24 +179,81 @@ jobs:
           # Write feedback to file — Goose reads it directly (not via template substitution)
           printf '%s\n' "$REVIEW_FEEDBACK" > /tmp/review-feedback.txt
 
-          # Goose sometimes hangs after completing work (doesn't exit despite --no-session).
-          # Use timeout to kill it after 45 min — the job timeout is 60 min, leaving 15 min
-          # for the commit/push/comment steps. Exit code 124 = timeout (treat as success if
-          # Goose made changes, since it completed work but just didn't exit).
-          exit_code=0
-          timeout 2700 goose run \
-            --recipe .github/goose-recipes/wgmesh-review.yaml \
-            --no-session \
-            2>&1 | tee /tmp/goose-review-output.log || exit_code=$?
+          RECIPE=".github/goose-recipes/wgmesh-review.yaml"
 
-          if [ "$exit_code" -eq 0 ] || [ "$exit_code" -eq 124 ]; then
-            echo "goose_ok=true" >> "$GITHUB_OUTPUT"
-            if [ "$exit_code" -eq 124 ]; then
-              echo "::warning::Goose timed out (likely hung after completing work)"
+          # Provider cascade: try OpenRouter first, fall back to Anthropic direct.
+          # Each attempt: run Goose with a 2-min probe to check for credit/auth errors,
+          # then if the probe succeeds, run the full 45-min session.
+          run_goose() {
+            local provider="$1" model="$2" label="$3"
+            echo "::group::Trying $label ($provider/$model)"
+
+            # Patch recipe with this provider/model
+            sed -i "s|goose_provider:.*|goose_provider: \"$provider\"|" "$RECIPE"
+            sed -i "s|goose_model:.*|goose_model: \"$model\"|" "$RECIPE"
+
+            # Quick probe: run for 2 min to check for credit/auth errors
+            local probe_code=0
+            timeout 120 goose run \
+              --recipe "$RECIPE" \
+              --no-session \
+              2>&1 | tee /tmp/goose-review-output.log || probe_code=$?
+
+            # Check for credit/auth errors in output
+            if grep -qiE '(add more credits|insufficient.*(funds|credits|balance)|rate.limit|unauthorized|api.key.not.found)' /tmp/goose-review-output.log; then
+              echo "::warning::$label: credit/auth error detected, trying next provider"
+              echo "::endgroup::"
+              return 1
             fi
-          else
-            echo "goose_ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Goose exited with status $exit_code"
+
+            # If probe timed out (124), Goose is working — it just needs more time.
+            # If probe exited 0, Goose finished quickly. Either way, check for changes.
+            if [ "$probe_code" -eq 0 ] || [ "$probe_code" -eq 124 ]; then
+              if [ "$probe_code" -eq 124 ]; then
+                echo "Goose is working, continuing with full timeout..."
+                # Goose was killed by probe timeout — reset and run with full timeout.
+                # Restore pre-Goose state to avoid partial work.
+                git checkout -- . 2>/dev/null || true
+                git clean -fd 2>/dev/null || true
+
+                local full_code=0
+                timeout 2700 goose run \
+                  --recipe "$RECIPE" \
+                  --no-session \
+                  2>&1 | tee /tmp/goose-review-output.log || full_code=$?
+
+                if [ "$full_code" -eq 0 ] || [ "$full_code" -eq 124 ]; then
+                  [ "$full_code" -eq 124 ] && echo "::warning::Goose timed out (likely hung after completing work)"
+                  echo "::endgroup::"
+                  return 0
+                else
+                  echo "::warning::$label: Goose exited with status $full_code"
+                  echo "::endgroup::"
+                  return 1
+                fi
+              fi
+              # probe_code 0 means Goose finished within 2 min
+              echo "::endgroup::"
+              return 0
+            fi
+
+            echo "::warning::$label: Goose exited with status $probe_code"
+            echo "::endgroup::"
+            return 1
+          }
+
+          goose_ok=false
+
+          # Cascade: OpenRouter → Anthropic direct
+          if [ -n "$OPENROUTER_API_KEY" ] && run_goose "openrouter" "anthropic/claude-sonnet-4" "OpenRouter"; then
+            goose_ok=true
+          elif [ -n "$ANTHROPIC_API_KEY" ] && run_goose "anthropic" "claude-sonnet-4-20250514" "Anthropic"; then
+            goose_ok=true
+          fi
+
+          echo "goose_ok=$goose_ok" >> "$GITHUB_OUTPUT"
+          if [ "$goose_ok" = false ]; then
+            echo "::warning::All providers failed"
           fi
 
       - name: Commit and push changes


### PR DESCRIPTION
When OpenRouter credits are exhausted ($3/day limit), Goose sits idle for 45 min. Now cascades:

1. **OpenRouter** (anthropic/claude-sonnet-4) — cheapest
2. **Anthropic direct** (claude-sonnet-4) — fallback

Each provider gets a 2-min probe to detect credit/auth errors before the full 45-min run. Both API keys passed as env vars.