### PR TITLE
fix(testlab): add SSH keepalive to prevent hung chaos tests

### DIFF
--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -95,6 +95,8 @@ run_on() {
     ssh -o StrictHostKeyChecking=no \
         -o UserKnownHostsFile=/dev/null \
         -o ConnectTimeout=10 \
+        -o ServerAliveInterval=15 \
+        -o ServerAliveCountMax=4 \
         -o LogLevel=ERROR \
         -i "$SSH_KEY_FILE" \
         "root@${ip}" "$@"
@@ -108,6 +110,8 @@ run_on_ok() {
     ssh -o StrictHostKeyChecking=no \
         -o UserKnownHostsFile=/dev/null \
         -o ConnectTimeout=10 \
+        -o ServerAliveInterval=15 \
+        -o ServerAliveCountMax=4 \
         -o LogLevel=ERROR \
         -i "$SSH_KEY_FILE" \
         "root@${ip}" "$@" 2>/dev/null || true
@@ -120,6 +124,9 @@ copy_to() {
     local ip="${NODE_IPS[$node]}"
     scp -o StrictHostKeyChecking=no \
         -o UserKnownHostsFile=/dev/null \
+        -o ConnectTimeout=10 \
+        -o ServerAliveInterval=15 \
+        -o ServerAliveCountMax=4 \
         -o LogLevel=ERROR \
         -i "$SSH_KEY_FILE" \
         "$src" "root@${ip}:${dst}"


### PR DESCRIPTION
## Summary

- Add `ServerAliveInterval=15` + `ServerAliveCountMax=4` to all SSH/SCP calls in test infrastructure
- Prevents SSH sessions from hanging indefinitely when remote has severe packet loss

## Problem

Tier 3 T14 (80% packet loss, evict+rejoin) hung for 99 minutes until the 120-min job timeout cancelled it. The `chaos_apply` puts 80% packet loss on the node's `eth0` (public network), which causes SSH sessions to hang — TCP retransmissions keep the connection alive but no data flows.

Run 23001664316 shows:
- Tiers 1, 2, 4, 5, 6, 7: **all pass**
- Tier 3: **cancelled** (T14 hung at 12:42, job timeout at 14:22)

## Fix

SSH keepalive (`ServerAliveInterval=15`, `ServerAliveCountMax=4`) kills idle sessions after ~60s. This lets the test fail fast instead of hanging the entire tier.

Applied to: `run_on()`, `run_on_ok()`, `copy_to()`

## Test plan

- [ ] Merge to main, tag v0.2.1-rc2
- [ ] Verify Tier 3 completes within timeout (T14 should fail fast, not hang)