### PR TITLE
fix(testlab): address PR #433 review — keepalive on all SSH sites

### DIFF
--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -103,7 +103,7 @@ run_on() {
 }
 
 # Run a command on a remote node, tolerating failure.
-# Returns the exit code without aborting.
+# Always returns 0 — errors are silently swallowed.
 run_on_ok() {
     local node="$1"; shift
     local ip="${NODE_IPS[$node]}"

--- a/testlab/cloud/provision.sh
+++ b/testlab/cloud/provision.sh
@@ -105,6 +105,8 @@ provision_vms() {
             -o StrictHostKeyChecking=no \
             -o UserKnownHostsFile=/dev/null \
             -o ConnectTimeout=5 \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=4 \
             -o LogLevel=ERROR \
             -i "$SSH_KEY_FILE" \
             "root@${ip}" "true"


### PR DESCRIPTION
## Summary

Addresses Copilot review comments on PR #433:

1. **SSH keepalive on all call sites** — Added `ServerAliveInterval=15` + `ServerAliveCountMax=4` to the remaining direct `ssh` call in `provision.sh` (wait-for-SSH probe). All other SSH calls already go through `run_on`/`run_on_ok` which were fixed in #433.

2. **Fix `run_on_ok` docstring** — The old comment said "Returns the exit code without aborting" but `|| true` swallows all errors. Updated to: "Always returns 0 — errors are silently swallowed."

## Test plan

- No behavioral change — the provision SSH probe already has a 120s `wait_for` timeout
- Docstring-only fix on `run_on_ok`