### PR TITLE
fix(testlab): address PR #437 review comments

### DIFF
--- a/testlab/cloud/chaos.sh
+++ b/testlab/cloud/chaos.sh
@@ -29,12 +29,22 @@
 
 set -euo pipefail
 
-# Validate a value is a positive integer.
+# Validate a value is a non-negative integer (0 or greater).
 # Usage: _validate_int <value> <label>
 _validate_int() {
     local val="$1" label="$2"
     if ! [[ "$val" =~ ^[0-9]+$ ]]; then
-        log_error "chaos: invalid $label '$val' (must be a positive integer)"
+        log_error "chaos: invalid $label '$val' (must be a non-negative integer)"
+        return 1
+    fi
+}
+
+# Validate a value is an integer in 0-100 range (for tc netem percent params).
+# Usage: _validate_pct <value> <label>
+_validate_pct() {
+    _validate_int "$1" "$2" || return 1
+    if [ "$1" -gt 100 ]; then
+        log_error "chaos: $2 '$1' exceeds 100"
         return 1
     fi
 }
@@ -100,8 +110,7 @@ chaos_apply() {
     case "$type" in
         loss)
             local pct="${1:?loss percent required}"
-            _validate_int "$pct" "loss percent" || return 1
-            [ "$pct" -gt 100 ] && { log_error "chaos: loss percent '$pct' exceeds 100"; return 1; }
+            _validate_pct "$pct" "loss percent" || return 1
             if [ "${pct}" -ge 50 ]; then
                 # For severe loss: apply qdisc AND schedule auto-clear in a
                 # SINGLE SSH command.  This avoids a second SSH call that would
@@ -128,26 +137,30 @@ chaos_apply() {
         throttle)
             local kbit="${1:?kbit required}"
             _validate_int "$kbit" "throttle kbit" || return 1
+            if [ "$kbit" -le 0 ]; then
+                log_error "chaos: invalid throttle kbit '$kbit' (must be greater than zero)"
+                return 1
+            fi
             run_on "$node" "tc qdisc add dev $iface root tbf rate ${kbit}kbit burst 32kbit latency 400ms"
             log_info "chaos: $node — throttled to ${kbit}kbit on $iface"
             ;;
         reorder)
             local pct="${1:?reorder percent required}"
-            _validate_int "$pct" "reorder percent" || return 1
+            _validate_pct "$pct" "reorder percent" || return 1
             local corr="${2:-50}"
-            _validate_int "$corr" "reorder correlation" || return 1
+            _validate_pct "$corr" "reorder correlation" || return 1
             run_on "$node" "tc qdisc add dev $iface root netem delay 10ms reorder ${pct}% ${corr}%"
             log_info "chaos: $node — ${pct}% reorder (corr=${corr}%) on $iface"
             ;;
         duplicate)
             local pct="${1:?duplicate percent required}"
-            _validate_int "$pct" "duplicate percent" || return 1
+            _validate_pct "$pct" "duplicate percent" || return 1
             run_on "$node" "tc qdisc add dev $iface root netem duplicate ${pct}%"
             log_info "chaos: $node — ${pct}% duplication on $iface"
             ;;
         corrupt)
             local pct="${1:?corrupt percent required}"
-            _validate_int "$pct" "corrupt percent" || return 1
+            _validate_pct "$pct" "corrupt percent" || return 1
             run_on "$node" "tc qdisc add dev $iface root netem corrupt ${pct}%"
             log_info "chaos: $node — ${pct}% corruption on $iface"
             ;;

--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -89,41 +89,46 @@ emit_event() {
 
 # Shared SSH options — single source of truth for all remote commands.
 # ConnectTimeout=10s, keepalive every 15s with 4 retries (~60s dead session kill).
-_ssh_opts() {
-    echo -o StrictHostKeyChecking=no \
-         -o UserKnownHostsFile=/dev/null \
-         -o ConnectTimeout=10 \
-         -o ServerAliveInterval=15 \
-         -o ServerAliveCountMax=4 \
-         -o LogLevel=ERROR \
-         -i "$SSH_KEY_FILE"
+# Populated lazily (SSH_KEY_FILE must be set before first use).
+SSH_OPTS=()
+_ensure_ssh_opts() {
+    [ ${#SSH_OPTS[@]} -gt 0 ] && return
+    SSH_OPTS=(
+        -o StrictHostKeyChecking=no
+        -o UserKnownHostsFile=/dev/null
+        -o ConnectTimeout=10
+        -o ServerAliveInterval=15
+        -o ServerAliveCountMax=4
+        -o LogLevel=ERROR
+        -i "$SSH_KEY_FILE"
+    )
 }
 
 # Run a command on a remote node via SSH.
 # Usage: run_on <node-name> <command...>
 run_on() {
+    _ensure_ssh_opts
     local node="$1"; shift
     local ip="${NODE_IPS[$node]}"
-    # shellcheck disable=SC2046
-    ssh $(_ssh_opts) "root@${ip}" "$@"
+    ssh "${SSH_OPTS[@]}" "root@${ip}" "$@"
 }
 
 # Run a command on a remote node, tolerating failure.
 # Always returns 0 — errors are silently swallowed.
 run_on_ok() {
+    _ensure_ssh_opts
     local node="$1"; shift
     local ip="${NODE_IPS[$node]}"
-    # shellcheck disable=SC2046
-    ssh $(_ssh_opts) "root@${ip}" "$@" 2>/dev/null || true
+    ssh "${SSH_OPTS[@]}" "root@${ip}" "$@" 2>/dev/null || true
 }
 
 # Copy a file to a remote node.
 # Usage: copy_to <node-name> <local-path> <remote-path>
 copy_to() {
+    _ensure_ssh_opts
     local node="$1" src="$2" dst="$3"
     local ip="${NODE_IPS[$node]}"
-    # shellcheck disable=SC2046
-    scp $(_ssh_opts) "$src" "root@${ip}:${dst}"
+    scp "${SSH_OPTS[@]}" "$src" "root@${ip}:${dst}"
 }
 
 # Run a command on ALL nodes in parallel, wait for all.

--- a/testlab/cloud/provision.sh
+++ b/testlab/cloud/provision.sh
@@ -101,8 +101,8 @@ provision_vms() {
     for name in "${names[@]}"; do
         local ip
         ip=$(hcloud server ip "$name")
-        # shellcheck disable=SC2046
-        wait_for "SSH on $name ($ip)" 120 ssh $(_ssh_opts) "root@${ip}" "true"
+        _ensure_ssh_opts
+        wait_for "SSH on $name ($ip)" 120 ssh "${SSH_OPTS[@]}" "root@${ip}" "true"
     done
 
     log_info "All VMs reachable via SSH"


### PR DESCRIPTION
## Summary
- Convert `_ssh_opts()` echo-string to `SSH_OPTS` array — proper quoting, no shellcheck suppression
- Add `_validate_pct()` helper for 0-100 range on all tc netem percent params
- Add `>0` check for throttle kbit (tc tbf rate 0kbit is invalid)
- Fix `_validate_int` wording: "non-negative integer"

## Test plan
- [ ] `bash -n` passes on all 3 files
- [ ] Integration tests pass