### PR TITLE
fix: switch Goose from Google to z.ai provider

### DIFF
--- a/.github/goose-recipes/wgmesh-implementation.yaml
+++ b/.github/goose-recipes/wgmesh-implementation.yaml
@@ -64,8 +64,8 @@ extensions:
     name: developer
 
 settings:
-  goose_provider: "openrouter"
-  goose_model: "anthropic/claude-sonnet-4"
+  goose_provider: "openai"
+  goose_model: "glm-5.1"
   max_turns: 50
 
 retry:

--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -25,7 +25,8 @@ permissions:
 
 env:
   OPENAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
-  OPENAI_BASE_URL: "https://api.z.ai/api/paas/v4"
+  OPENAI_HOST: "https://api.z.ai"
+  OPENAI_BASE_PATH: "/api/paas/v4"
 
 jobs:
   implement:

--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -24,7 +24,8 @@ permissions:
   issues: write
 
 env:
-  GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+  OPENAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+  OPENAI_BASE_URL: "https://api.z.ai/api/paas/v4"
 
 jobs:
   implement:
@@ -46,10 +47,10 @@ jobs:
       # ── Validate prerequisites ──────────────────────────
       - name: Validate API key is configured
         env:
-          KEY: ${{ secrets.GOOGLE_API_KEY }}
+          KEY: ${{ secrets.ZAI_API_KEY }}
         run: |
           if [ -z "$KEY" ]; then
-            echo "::error::GOOGLE_API_KEY secret is not configured. Add it in Settings > Secrets > Actions."
+            echo "::error::ZAI_API_KEY secret is not configured. Add it in Settings > Secrets > Actions."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Switches Goose LLM provider from `GOOGLE_API_KEY` to `ZAI_API_KEY`
- Sets `OPENAI_BASE_URL` to z.ai's OpenAI-compatible endpoint
- Updates recipe provider from `openrouter` to `openai` with matching model name

## Problem

`GOOGLE_API_KEY` expired/revoked, causing every Goose build to fail at the validation step since March 1. 40 days of dead implementation pipeline — specs get written but never implemented.

## Test plan

- [ ] Trigger a Goose build manually via workflow_dispatch on an existing spec
- [ ] Verify API key validation passes
- [ ] Verify Goose can call z.ai and produce code changes