### PR TITLE
fix: remove invalid fields from Goose recipe

### DIFF
--- a/.github/goose-recipes/wgmesh-implementation.yaml
+++ b/.github/goose-recipes/wgmesh-implementation.yaml
@@ -63,18 +63,6 @@ extensions:
   - type: builtin
     name: developer
 
-settings:
-  goose_provider: "openai"
-  goose_model: "glm-5.1"
-  max_turns: 50
-
-retry:
-  max_retries: 2
-  timeout_seconds: 300
-  checks:
-    - type: shell
-      command: "go build ./..."
-    - type: shell
-      command: "go test ./..."
-    - type: shell
-      command: "go vet ./..."
+# Provider and model are configured via env vars in goose-build.yml:
+#   OPENAI_API_KEY, OPENAI_HOST, OPENAI_BASE_PATH
+# Build verification is handled in the workflow's "Check for changes" step.


### PR DESCRIPTION
## Summary

The `settings` and `retry` blocks in the recipe YAML are not valid Goose recipe fields. They caused every Goose run to fail with:

```
Error: Invalid recipe: could not find expected ':'
```

This was the **third and final blocker** preventing Goose from working:
1. ~~GOOGLE_API_KEY expired~~ (fixed in #479)
2. ~~goose-build-context.sh missing~~ (fixed in #481)
3. **Invalid recipe YAML** (this PR)

## Test plan

- [ ] Re-trigger Goose: `gh workflow run goose-build.yml --ref main -f issue_number=470 -f spec_pr_number=482`
- [ ] Verify recipe parses without error
- [ ] Verify Goose actually calls the LLM and produces code changes