### PR TITLE
fix: Goose recipe input_type file→string

### DIFF
--- a/.github/goose-recipes/wgmesh-implementation.yaml
+++ b/.github/goose-recipes/wgmesh-implementation.yaml
@@ -4,7 +4,7 @@ description: "Implements code and/or documentation changes for wgmesh based on a
 
 parameters:
   - key: spec_file
-    input_type: file
+    input_type: string
     requirement: required
     description: "Path to the specification file (specs/issue-N-spec.md)"
 


### PR DESCRIPTION
## Summary

**This is THE fix.** Every Goose build since the recipe was created has failed because `input_type: file` causes Goose to inject the spec file's markdown content into the YAML template before parsing. Colons in markdown (`:`) break the YAML parser.

Changing to `input_type: string` passes just the file path. The prompt already tells Goose to "read the specification file" — it uses the developer extension to read it.

Tested locally with Goose 1.30.0 — recipe loads successfully.

## Root cause chain (all 4 fixed now)

1. ~~GOOGLE_API_KEY expired~~ (#479)
2. ~~goose-build-context.sh missing~~ (#481)  
3. ~~Invalid settings/retry blocks~~ (#483) — turned out these WERE valid
4. **`input_type: file` breaks YAML parsing** (this PR)

## Test plan

- [ ] `gh workflow run goose-build.yml --ref main -f issue_number=470 -f spec_pr_number=482`
- [ ] Verify `goose_duration > 0` and `goose_lines > 1`
- [ ] Verify `has_changes = true` and a PR is created