### PR TITLE
fix: add settings block for Goose provider config

### DIFF
--- a/.github/goose-recipes/wgmesh-implementation.yaml
+++ b/.github/goose-recipes/wgmesh-implementation.yaml
@@ -49,3 +49,7 @@ prompt: |
   real codebase, adapt to match reality.
 
   Now implement the specification in {{ spec_file }}.
+
+settings:
+  goose_provider: "openai"
+  goose_model: "glm-5.1"


### PR DESCRIPTION
## Summary

Goose needs `goose_provider` and `goose_model` in the recipe settings to know which LLM to use. We removed these in #483 thinking they were invalid — they're required.

Tested locally with Goose 1.30.0:
```
Loading recipe: wgmesh Implementation
● new session · openai glm-5.1
goose is ready
```

Only fails on auth (no API key locally) — CI has the key via env vars.

## Test plan

- [ ] `gh workflow run goose-build.yml --ref main -f issue_number=470 -f spec_pr_number=482`
- [ ] Verify Goose starts a session (duration > 0, lines > 1)
- [ ] Verify code changes produced (has_changes = true)