### PR TITLE
fix: use OPENAI_BASE_URL for z.ai endpoint

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -25,8 +25,7 @@ permissions:
 
 env:
   OPENAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
-  OPENAI_HOST: "https://api.z.ai"
-  OPENAI_BASE_PATH: "/api/paas/v4"
+  OPENAI_BASE_URL: "https://api.z.ai/api/paas/v4"
 
 jobs:
   implement:


### PR DESCRIPTION
Goose 1.30.0 mishandles OPENAI_HOST+OPENAI_BASE_PATH (sends to /v4 instead of /api/paas/v4). OPENAI_BASE_URL passes the full URL directly.