### PR TITLE
fix: use z.ai coding endpoint

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -25,7 +25,7 @@ permissions:
 
 env:
   OPENAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
-  OPENAI_BASE_URL: "https://api.z.ai/api/paas/v4"
+  OPENAI_BASE_URL: "https://api.z.ai/api/coding/paas/v4"
 
 jobs:
   implement:


### PR DESCRIPTION
The paas/v4 endpoint rejects the GLM Coding Plan API key. The coding/paas/v4 endpoint is what the review workflow uses successfully.