### PR TITLE
docs: add STRATEGY.md and align ROADMAP/FEATURE_MATRIX

### DIFF
--- a/FEATURE_MATRIX.md
+++ b/FEATURE_MATRIX.md
@@ -1,0 +1,153 @@
+# Feature Matrix
+
+Two views of the same underlying inventory.
+
+1. **Competitive matrix** — wgmesh against the tools people actually consider when they shop for "WireGuard mesh."
+2. **Internal feature inventory** — what wgmesh ships today, by mode, with status.
+
+---
+
+## 1. Competitive Matrix
+
+Scoring legend: ✅ shipped · 🟡 partial / limited · 🔧 self-hostable but bring-your-own · ❌ no.
+
+The "honest" column is where wgmesh is behind. Don't hide it on the landing page; the people we want as users will catch it.
+
+| Capability | wgmesh | Tailscale | Headscale | Netbird | ZeroTier | Innernet | Nebula | EasyTier |
+|---|---|---|---|---|---|---|---|---|
+| **Coordination server required** | ❌ none (DHT) | ✅ SaaS | 🔧 self-host | ✅ SaaS or self-host | ✅ Earth roots | ✅ central server | 🔧 lighthouses | 🔧 trackers |
+| **Bootstrap UX** | one secret | account + login | account + login | account + login | network ID + auth | invitation files | cert authority + config | name + secret |
+| **NAT traversal** | ✅ DHT-driven | ✅ DERP relays | 🟡 needs DERP | ✅ Coturn/STUN | ✅ Earth relays | 🟡 limited | ✅ lighthouses | ✅ public relays |
+| **Works fully offline (LAN)** | ✅ multicast | ❌ needs control plane | ❌ needs control plane | ❌ needs control plane | ❌ needs Earth | ❌ needs server | 🟡 needs lighthouse | 🟡 needs tracker |
+| **Routable subnets** | ✅ both modes | ✅ subnet routers | ✅ | ✅ | ✅ bridging | ✅ CIDRs | ✅ unsafe_routes | ✅ |
+| **ACLs / segmentation** | ✅ centralized only | ✅ HuJSON ACLs | ✅ | ✅ groups + rules | ✅ flow rules | ✅ CIDR-based | ✅ groups | 🟡 |
+| **Magic DNS / name resolution** | ❌ | ✅ | ✅ | ✅ | 🟡 | ❌ | ❌ | 🟡 |
+| **Mobile clients (iOS/Android)** | ❌ | ✅ | ✅ via Tailscale app | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **Web dashboard / GUI** | 🟡 chimney (read-only) | ✅ | 🟡 | ✅ | ✅ | ❌ | ❌ | 🟡 |
+| **SSO / OIDC / SAML** | ❌ | ✅ | 🟡 OIDC | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **Audit logs** | ❌ | ✅ | 🟡 | ✅ | ✅ | ❌ | 🟡 | ❌ |
+| **Open source** | ✅ MIT | 🟡 client only | ✅ BSD-3 | ✅ BSD-3 | ✅ BSL-1.1 | ✅ MIT | ✅ MIT | ✅ Apache-2 |
+| **Self-hostable end-to-end** | ✅ no server at all | ❌ | ✅ | ✅ | 🟡 | ✅ | ✅ | ✅ |
+| **Encrypted state at rest** | ✅ AES-256-GCM | n/a | 🟡 DB-level | 🟡 DB-level | n/a | 🟡 | 🟡 | ❌ |
+| **EU-based / GDPR-friendly** | ✅ Hetzner, deSEC | ❌ US | depends on host | depends on host | ❌ US | depends on host | depends on host | depends on host |
+| **Vendor lock-in risk** | low | high | low | medium | high | low | low | medium |
+| **Time-to-mesh (LAN)** | <5s | ~30s | ~30s | ~30s | ~30s | manual | manual | ~30s |
+| **Time-to-mesh (Internet)** | 15–60s | 5–10s | 5–10s | 5–10s | 5–10s | manual | 10–30s | 30–60s |
+| **CLI-only operation** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Maintained by** | solo + AI agents | YC company | community | YC company | ZeroTier Inc. | Tonari | Defined Networking | community |
+
+### Where wgmesh wins
+
+- **No coordination server.** This is the thing nobody else has. The cost of running Tailscale-the-protocol at home is "trust Tailscale's control plane or run Headscale." wgmesh removes the question.
+- **Works offline.** A LAN with no internet still meshes. None of the SaaS tools do this.
+- **One secret, no accounts.** No OIDC dance, no email verification, no admin console. Useful for ad-hoc, ephemeral, or air-gapped setups.
+- **Encrypted state file.** Vault-friendly out of the box for centralized mode.
+- **EU-first.** Hetzner, deSEC, Migadu — matters for buyers who care about data residency.
+
+### Where wgmesh loses (don't pretend otherwise)
+
+- **No mobile.** Tailscale on an iPhone is the killer feature for road warriors. wgmesh can't do it yet.
+- **No SSO.** Means it's not enterprise-shaped. Means your buyer is a homelabber, not a CISO.
+- **No magic DNS.** People grow to love `ssh node1` instead of `ssh 10.99.0.1`. We don't do that yet.
+- **No managed offering.** Tailscale's free tier solves "I just want it to work." We don't have that path.
+- **Smaller community.** Tailscale has tens of thousands of GitHub stars, Discord channels, blog posts. We have ~200 stars and a Show HN draft.
+- **DHT discovery is slower.** 15–60s vs Tailscale's 5–10s. The control-server tools win on time-to-first-connection.
+
+### Positioning that holds up
+
+> wgmesh is for people who'd rather operate a mesh than rent one. If your reaction to "Tailscale's control plane" is "I'd rather not," wgmesh is the tool. If your reaction is "fine, sounds easy," Tailscale is the tool.
+
+---
+
+## 2. Internal Feature Inventory
+
+Two operating modes, two surface areas. Status: ✅ shipped · 🟡 partial · 🔧 in-flight · 📋 spec'd not built · ❌ not started.
+
+### Centralized mode (`pkg/mesh`, `pkg/ssh`)
+
+| Feature | Status | Notes |
+|---|---|---|
+| `init / add / remove / list / deploy` CLI | ✅ | The original surface |
+| State file (`mesh-state.json`) | ✅ | JSON, auto-created at `/var/lib/wgmesh/` |
+| Encrypted state (`--encrypt`) | ✅ | AES-256-GCM + PBKDF2 100k iters, vault-friendly |
+| Diff-based `wg set` updates | ✅ | No interface restart |
+| SSH-based config push | ✅ | Tries agent, then `id_rsa`, `id_ed25519`, `id_ecdsa` |
+| **SSH host key verification** | ❌ | `InsecureIgnoreHostKey` — gap in security posture |
+| Auto-install of WireGuard on remote | ✅ | apt/yum/dnf detection |
+| NAT detection (compare SSH host vs public IP) | ✅ | |
+| `routable_networks` (subnet routing) | ✅ | Both direct and via-peer routes |
+| Group-based access control | ✅ | Issue #176; policies + `AllowedIPs` enforcement |
+| systemd persistence (`wg-quick@wg0`) | ✅ | |
+| Custom mesh subnet | ✅ | Default `10.99.0.0/16` |
+
+### Decentralized mode (`pkg/daemon`, `pkg/discovery`, `pkg/crypto`)
+
+| Feature | Status | Notes |
+|---|---|---|
+| `init --secret / join / status / qr` | ✅ | |
+| `wgmesh://v1/<base64>` token format | ✅ | |
+| HKDF-derived keys (`pkg/crypto/derive.go`) | ✅ | network_id, gossip_key, mesh_subnet, multicast_id, PSK |
+| Deterministic mesh IP from pubkey | ✅ | Collision resolution by lexicographic pubkey |
+| 5-second reconcile loop | ✅ | `pkg/daemon/daemon.go` |
+| SIGHUP hot reload | ✅ | `advertise-routes`, `log-level` |
+| Persistent peer cache | ✅ | Survives daemon restart |
+| Discovery L0: GitHub Issue rendezvous | ✅ | `pkg/discovery/registry.go` |
+| Discovery L1: LAN multicast | ✅ | `239.192.x.x` derived from secret |
+| Discovery L2: BitTorrent DHT | ✅ | `anacrolix/dht/v2`, hourly infohash rotation |
+| Discovery L3: In-mesh gossip | ✅ | `--gossip` flag |
+| Encrypted peer exchange | ✅ | AES-256-GCM envelopes |
+| Dandelion++ stem-fluff routing | ✅ | `pkg/privacy/dandelion.go` |
+| Membership tokens | ✅ | `pkg/crypto/membership.go` |
+| Epoch management | ✅ | `pkg/daemon/epoch.go` |
+| Relay routing fallback | 🟡 | Spec exists, partially wired |
+| RPC: Unix socket JSON-RPC | ✅ | `peers.list/get/count`, `daemon.status/ping` |
+| `wgmesh peers list` table | 🟡 | Truncated pubkeys (#178), no hostname (#81 phase 3) |
+| `test-peer` connectivity probe | ✅ | |
+| Hostname in peer announcements | 🟡 | Field exists in `PeerInfo`, not in wire format |
+| **ACLs / segmentation** | ❌ | Centralized has it, decentralized doesn't |
+| **Secret rotation protocol** | 📋 | In `features/archived/bootstrap.md`, deferred |
+| **STUN integration** | 📋 | Open question in archived plan |
+| **TURN/relay fallback for CGNAT** | 📋 | Open question |
+| **IPv6 mesh subnet** | ❌ | |
+| **DNS / name resolution** | ❌ | No magic-DNS equivalent |
+
+### Operational surface
+
+| Item | Status | Notes |
+|---|---|---|
+| Linux builds (amd64, arm64, armv7) | ✅ | goreleaser on `v*.*.*` |
+| Darwin builds (amd64, arm64) | ✅ | Issue #24 |
+| `.deb` / `.rpm` packages | ✅ | |
+| Homebrew formula | ✅ | |
+| Docker image (`ghcr.io/...`) | ✅ | |
+| Docker Compose recipe | ✅ | `DOCKER-COMPOSE.md` |
+| Nix package | 🔧 | Plan in `memory/plan - 2603012134 - distributable packages...` |
+| systemd unit generation | 🟡 | Centralized only |
+| `wgmesh install-service` | 📋 | Phase 4 of original plan |
+
+### Adjacent / business surface
+
+| Item | Status | Notes |
+|---|---|---|
+| Chimney dashboard | ✅ | Extracted to its own repo; live at chimney.beerpub.dev |
+| Lighthouse CDN control plane | ✅ | Extracted; not yet productized |
+| `lighthouse-go` SDK | ✅ | `wgmesh service` subcommand uses it |
+| `wgmesh service add` CLI | 📋 | Issue #372, in triage |
+| Autonomous AI dev pipeline | ✅ | Goose builds, Copilot reviews, auto-merge |
+| Landing page (cloudroof.eu) | 🟡 | Placeholder; needs repositioning per first-customer brainstorm |
+| Polar.sh billing | 🔧 | Issue #376, needs-human |
+| Cost tracking | 🔧 | Issue #373, `costs.json` has nulls |
+| GitHub Sponsors tiers | ✅ | Contributor $5 / Edge Node $20 / Mesh Operator $100 |
+| First paying customer | ❌ | The thing this whole thing is about |
+
+---
+
+## What this matrix tells us
+
+Three things stand out when you read both halves together.
+
+The first is that **the technical product is much more complete than the commercial product**. The internal inventory has a lot of green; the business surface has almost none. The gap to first paying customer is not "build more features," it's "wire up Polar.sh, ship the Show HN, find one human."
+
+The second is that **the competitive losses cluster in one place: the surfaces a non-technical buyer sees**. No mobile, no SSO, no GUI, no magic DNS. If the ICP is homelabbers and small ops teams who already think in terminals, this matters less. If the ICP becomes "the CTO of a 50-person company," every red cell becomes a deal-blocker.
+
+The third is that **the differentiator is structural, not feature-based**. You can't add "no coordination server" to Tailscale; that's the architecture. Everyone else's roadmap can copy our checkboxes; nobody else's roadmap can copy the absence of a control plane. That's the moat. Defend it in marketing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,116 @@
+# Roadmap
+
+Three horizons. Each item has a one-line rationale because in six months we'll forget why it was on the list.
+
+The roadmap is organized two ways:
+
+- **By horizon** — Now / Next / Later, with rough quarterly buckets.
+- **By bet** — what we believe will produce the first paying customer, what we believe will produce the tenth, what we believe will produce the hundredth.
+
+The two views overlap intentionally. If they diverge, that's the bug — fix the one that's wrong.
+
+---
+
+## Horizon 1 — Now (Q2 2026, next ~8–12 weeks)
+
+The theme is **close the gap to the first paying customer**. Most of these are not engineering; the engineering items are the ones that block the commercial items.
+
+| # | Item | Owner | Why now |
+|---|---|---|---|
+| 1 | Polar.sh billing wired up (#376) | needs-human | GitHub Sponsors has too many steps. Conversion blocker per first-customer brainstorm. |
+| 2 | Cost tracking populated (#373) | needs-human | Can't compute runway with €2400 capital and `costs.json` full of nulls. |
+| 3 | Landing page repositioning (cloudroof.eu) | needs-human | Currently opaque to non-engineers. ICP needs to recognize themselves above the fold. |
+| 4 | Show HN post + stargazer outreach | Marty | Distribution. The autonomous pipeline is the story; ship it before the hype window closes. |
+| 5 | "Homelab to VPS in 5 minutes" tutorial | Marty | SEO-friendly, shareable, converts the drive-by visitor. |
+| 6 | `wgmesh service add` CLI spec (#372) | dev pipeline | Foundation-stage blocker called out in the assessments. |
+| 7 | Hostname propagation in peer announcements (#81 phase 3, #181) | dev pipeline | `peers list` shows truncated pubkeys instead of hostnames. Embarrassing during demos. |
+| 8 | Truncated pubkey copy-paste fix (#178) | dev pipeline | You can't `peers get` what you can't paste. |
+| 9 | SSH host key verification | dev pipeline | `InsecureIgnoreHostKey` is the only thing preventing a credible "we take security seriously" claim. |
+| 10 | Secret rotation protocol | dev pipeline | Promised in archived bootstrap plan, still not built. Single biggest "what if my secret leaks" gap. |
+| 11 | Nix package (`memory/plan - 2603012134`) | dev pipeline | `nix run github:atvirokodosprendimai/wgmesh` is the 30-second try-it path. |
+
+**Stage exit criterion:** one paying customer, even at $5/mo, and `costs.json` populated enough that the autonomous loop can compute runway.
+
+---
+
+## Horizon 2 — Next (Q3 2026)
+
+The theme is **make the product feel real to a buyer who isn't already convinced**. After Q2, we should have a few users; Q3 is about giving the next ten of them what's currently missing.
+
+| # | Item | Why |
+|---|---|---|
+| 1 | Decentralized ACLs | Centralized has groups + policies. Decentralized doesn't. Closes the parity gap and unblocks "real" deployments. |
+| 2 | STUN integration (`pion/stun`) | Cleaner endpoint detection than the current SSH-host-comparison heuristic. |
+| 3 | TURN / relay fallback | For nodes behind strict CGNAT. Currently they just fail; EasyTier handles this and we don't. |
+| 4 | Web dashboard (mesh management) | Read-only is fine for now. Lives on Chimney. The first thing a buyer asks for after CLI. |
+| 5 | DNS / mesh-internal name resolution | `ssh node1` instead of `ssh 10.99.0.5`. Tailscale's MagicDNS is the feature people miss most. |
+| 6 | IPv6 mesh subnet | Currently /16 IPv4 only. Some prospects will literally not consider us without v6. |
+| 7 | Lighthouse CDN: managed ingress productized | The thing the $20 Edge Node tier is selling. Currently the code exists; the offering doesn't. |
+| 8 | Self-serve signup | The path from "I read the Show HN" to "I have a working mesh" without DMing the founder. |
+| 9 | `wgmesh install-service` | Phase 4 of the original plan. systemd unit generation for decentralized mode. |
+| 10 | Mistral evaluation for control loop | EU-native LLM as a hedge against OpenRouter availability and as a positioning consistency check. |
+| 11 | Multi-region edge proxies | Required for the CDN narrative to hold. Until we have nodes in 3+ regions, "anycast CDN" is a sketch. |
+
+**Stage exit criterion:** ~10 paying customers, the dashboard at chimney.beerpub.dev shows them by name, and the Lighthouse-managed-ingress is something a stranger can sign up for without our help.
+
+---
+
+## Horizon 3 — Later (Q4 2026 – Q1 2027)
+
+The theme is **become legible to a buyer who wasn't a homelabber to start with**. This is where the "no coordination server" architecture either continues to be the moat or becomes the thing we have to apologize for.
+
+| # | Item | Why |
+|---|---|---|
+| 1 | Mobile clients (iOS/Android) | The killer feature road warriors won't compromise on. wireguard-go-based, with the daemon's discovery layer ported. Hard but unavoidable. |
+| 2 | SSO / OIDC for centralized mode | Makes the product legible to enterprise IT. Without it we are not in the conversation. |
+| 3 | Audit logging | Not for the homelabber. For the buyer who has to write a SOC 2 control. |
+| 4 | Compliance posture (GDPR doc, SOC 2 readiness) | The EU positioning is a real edge but only if we can produce the artifacts on request. |
+| 5 | Plugin / integration ecosystem | Terraform provider, Coolify integration, GitHub Action. Each one is a distribution channel. |
+| 6 | Automated customer health scoring | Per first-customer spec. When you have 100 customers you can no longer remember who is healthy. |
+| 7 | Web dashboard: full read-write | Add/remove nodes, manage groups, edit policies. The thing that lets a non-CLI person operate a mesh. |
+| 8 | Public floodfill / garlic bundling | Privacy features deferred from the bootstrap plan. Only matters if we pick up an adversarial-network use case. |
+
+**Stage exit criterion:** a coherent commercial offering that a buyer can evaluate in <30 minutes without talking to us, and the autonomous loop is responsible for routine support and upsell.
+
+---
+
+## By Bet
+
+Same items, regrouped by what we think they'll produce. The horizons answer "when"; the bets answer "why."
+
+### Bet A — First paying customer (next 12 weeks)
+Polar.sh, cost tracking, landing page rewrite, Show HN, stargazer outreach, the 5-minute tutorial.
+*Belief: the technical product is good enough; the path to revenue is reducing friction and finding the first human, not building more features.*
+
+### Bet B — Tenth paying customer (Q3)
+Decentralized ACLs, STUN/TURN, DNS, Lighthouse-managed-ingress, self-serve signup, IPv6.
+*Belief: the next nine customers each want a thing the first customer didn't ask about. The job is to build the smallest list that covers the most of them.*
+
+### Bet C — Hundredth paying customer (Q4–Q1)
+Mobile, SSO, audit logs, GDPR/SOC 2 posture, plugin ecosystem, full-write dashboard.
+*Belief: somewhere around customer 30 we stop selling to homelabbers and start selling to small companies. They want different things. We should know which group we're talking to.*
+
+### Bet D — The thing that probably won't work but should be tried anyway
+Indie integrations: Coolify, CapRover, Coolify-style PaaS networking. The "AI inference mesh" angle. Terraform provider. Each of these is a 1-in-5 chance of being the unlock.
+*Belief: most of these will be ignored. One might compound into the actual distribution channel. We won't know which until we try.*
+
+---
+
+## Things deliberately NOT on this roadmap
+
+Worth saying out loud so they don't keep showing up in standups.
+
+- **Hosted control plane for someone else's wgmesh deployment.** We are not Headscale-as-a-service. cloudroof.eu uses wgmesh internally as part of a bundled edge offering; we don't sell a control plane for your mesh.
+- **Windows native client.** Linux + Docker covers the homelab market. Windows is mostly a way to lose two months and ship something worse than what's already in the box.
+- **Custom WireGuard fork.** Stay on upstream. Every fork I've seen of WG has regretted it within 18 months.
+- **Free tier with "limit removed in paid."** Either it's free or it's paid; the in-between makes the product feel cheap to evaluators.
+- **Proprietary protocol on top of WG.** Same reason as no fork. The WG protocol is the contract; layering proprietary stuff on top breaks interop, which is half the value.
+
+---
+
+## How this roadmap is maintained
+
+- **Source of truth is this file**, in the repo, on `main`. If something here disagrees with a slide, the slide is wrong.
+- **Each item links to a GitHub issue** once it's actively being worked. If an item is on this roadmap but has no issue and no owner after 30 days, it's not actually on the roadmap; delete it.
+- **Reviewed monthly** by checking the `memory/next - YYMMHHHH - aggregated actionable items` file against what's here. Drift is interesting; resolve it.
+- **The autonomous company loop** can propose additions but cannot silently delete items. Deletion requires a human (Marty) — these are decisions, not optimizations.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,65 @@
+---
+name: wgmesh
+last_updated: 2026-05-04
+---
+
+# wgmesh Strategy
+
+## Target problem
+
+Operators wiring agent fleets to edge nodes (e.g. exposing an openclaw webserver via cloudroof in minutes) need fast, ad-hoc, secure meshes. Existing tools either treat edge as second-class (Tailscale), feel bolted-on (Cloudflare Tunnel), or "work" in demos and fail at minute-3 of real ad-hoc setup.
+
+## Our approach
+
+wgmesh is autonomous — the mesh discovers, peers, and heals itself with no control plane to host or trust, so ad-hoc agent-to-edge setups complete in minutes and survive past minute-3.
+
+## Who it's for
+
+**Primary:** LLM agent builders running stacks like Hermes / openclaw — devs not devops, force-of-nature tinkerers who don't know ops and don't want to learn. They're hiring wgmesh to wire agents + services across boxes and edge in minutes, without becoming a sysadmin.
+
+## Key metrics
+
+- **Paying customers** — count of active Polar.sh subscriptions. Lagging.
+- **Cost coverage ratio** — MRR ÷ monthly cost. Single number for "are we alive."
+- **Weekly active meshes** — distinct rendezvous IDs alive in DHT/registry over rolling 7d. Source: chimney.
+- **Time-to-mesh (p50)** — median seconds from `wgmesh join` to first handshake on internet path. Source: daemon logs / synthetic probe.
+- **Unsolicited positive feedback rate** — count/week of GitHub issues, DMs, Show HN comments tagged positive.
+
+## Tracks
+
+### Mesh autonomy core
+
+Discovery layers (L0 GitHub / L1 LAN multicast / L2 DHT / L3 in-mesh gossip), reconcile loop, secret rotation, NAT survival.
+
+_Why it serves the approach:_ this **is** the autonomy — without a control plane, discovery and self-healing must be load-bearing reliable.
+
+### Edge as first-class
+
+Lighthouse CDN, managed ingress, the openclaw→cloudroof path. The use case Tailscale and Cloudflare both lose.
+
+_Why it serves the approach:_ autonomy extends to the edge node — no bolt-on tunnel, edge is a peer not an afterthought.
+
+### Commercial pipe (Bet A)
+
+Polar.sh billing, landing repositioning at cloudroof.eu, cost tracking, distribution (Show HN, tutorial, stargazer outreach).
+
+_Why it serves the approach:_ revenue without a growth/sales team — the autonomy thesis applied to the company itself.
+
+## Milestones
+
+- **2026-Q2** — first paying customer (any tier, even $5/mo) and `costs.json` populated enough to compute runway.
+- **2026-Q3** — ~10 paying customers, dashboard at chimney.beerpub.dev shows them by name, Lighthouse-managed-ingress is self-serve.
+
+## Not working on
+
+- **Hosted control plane for someone else's wgmesh deployment** — we are not Headscale-as-a-service. cloudroof.eu uses wgmesh internally as part of a bundled edge offering; we don't sell a control plane for your mesh.
+- **Windows native client** — Linux + Docker covers the homelab market. Two months to ship something worse than what's in the box.
+- **Custom WireGuard fork** — every WG fork has regretted it within 18 months. Stay on upstream.
+- **Free tier with "limit removed in paid"** — either it's free or it's paid; in-between makes the product feel cheap.
+- **Proprietary protocol on top of WG** — breaks interop, which is half the value.
+
+## Marketing
+
+**One-liner:** wgmesh — a WireGuard mesh that just works.
+
+**Key message:** If your reaction to "Tailscale's control plane" is "I'd rather not," wgmesh is the tool. If your reaction is "fine, sounds easy," Tailscale is the tool. No coordination server, no accounts, one secret, EU-first.


### PR DESCRIPTION
## Summary

- Adds `STRATEGY.md` at repo root — canonical short doc produced via `ce-strategy` interview. Captures target problem, guiding approach (autonomy / no control plane), primary persona (LLM agent builders running stacks like Hermes / openclaw — devs not devops), 5 metrics, and 3 tracks: mesh autonomy core / edge as first-class / commercial pipe.
- Adds `ROADMAP.md` (three horizons + bets view) and `FEATURE_MATRIX.md` (competitive matrix + internal inventory) as the grounding documents the strategy was distilled from.
- Resolves a tension between roadmap and strategy: `cloudroof.eu` is a bundled edge offering that uses wgmesh internally — *not* a hosted control plane for someone else's mesh. Old "wgmesh-as-a-service" not-working-on bullet rephrased to keep the discipline (no Headscale-as-a-service) without contradicting the cloudroof reality.

## Why now

Strategy doc was missing — downstream skills (`ce-ideate`, `ce-brainstorm`, `ce-plan`) read `STRATEGY.md` as grounding when present. Trio belongs together so future drift can be checked across all three.

## Test plan

- [ ] `STRATEGY.md` renders cleanly on GitHub.
- [ ] Frontmatter (`name`, `last_updated`) parses.
- [ ] No internal contradictions between `STRATEGY.md`, `ROADMAP.md`, `FEATURE_MATRIX.md` on the cloudroof / control-plane question.
- [ ] Marketing one-liner + key message align with current `cloudroof.eu` landing copy direction.