### PR TITLE
feat(observability): server-side PostHog instrumentation

### DIFF
--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -37,5 +37,25 @@ jobs:
           TARGET_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           APPROVED_AUTHORS: ${{ github.event.pull_request.user.login }}
+          POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
         run: |
           bash company/scripts/pr-review-merge.sh
+
+      - name: Emit bot_pr_merged to PostHog
+        if: always()
+        env:
+          POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          OUTCOME: ${{ job.status }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          PROPS=$(jq -nc \
+            --arg outcome "$OUTCOME" \
+            --arg pr "$PR_NUMBER" \
+            --arg author "$PR_AUTHOR" \
+            --arg title "$PR_TITLE" \
+            '{outcome: $outcome, pr_number: ($pr|tonumber), author: $author, title: $title}')
+          bash company/scripts/posthog-emit.sh bot_pr_merged "${PR_AUTHOR}" "$PROPS"

--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -43,19 +43,22 @@ jobs:
           bash company/scripts/pr-review-merge.sh
 
       - name: Emit bot_pr_merged to PostHog
-        if: always()
+        # hashFiles guard: posthog-emit.sh is added by PR #555 itself, so on
+        # main checkout it may be absent until merge. Skip silently when
+        # missing instead of failing CI.
+        if: always() && hashFiles('company/scripts/posthog-emit.sh') != ''
         env:
           POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
           POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
           OUTCOME: ${{ job.status }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          # PR_TITLE intentionally omitted: titles can leak tokens/emails
+          # (see PII incident 2026-05-09). Use PR_NUMBER + author only.
           PROPS=$(jq -nc \
             --arg outcome "$OUTCOME" \
             --arg pr "$PR_NUMBER" \
             --arg author "$PR_AUTHOR" \
-            --arg title "$PR_TITLE" \
-            '{outcome: $outcome, pr_number: ($pr|tonumber), author: $author, title: $title}')
-          bash company/scripts/posthog-emit.sh bot_pr_merged "${PR_AUTHOR}" "$PROPS"
+            '{outcome: $outcome, pr_number: ($pr|tonumber), author: $author}')
+          bash company/scripts/posthog-emit.sh bot_pr_merged "${PR_AUTHOR}" "$PROPS" || true

--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -562,3 +562,23 @@ jobs:
             -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
             -X POST -H 'Content-Type: application/json' \
             -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" || echo "::warning::mentisdb append failed (non-fatal)"
+
+      - name: Emit goose_build_run to PostHog
+        if: always()
+        env:
+          POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          OUTCOME: ${{ job.status }}
+          ISSUE: ${{ steps.spec.outputs.issue_number }}
+          SPEC_PR: ${{ steps.spec.outputs.spec_pr_number }}
+        run: |
+          # Goose checks out implementation branches mid-job; restore the
+          # helper from main so we don't depend on it existing on those
+          # older branches.
+          git checkout main -- company/scripts/posthog-emit.sh 2>/dev/null || true
+          PROPS=$(jq -nc \
+            --arg outcome "$OUTCOME" \
+            --arg issue "${ISSUE:-}" \
+            --arg spec_pr "${SPEC_PR:-}" \
+            '{outcome: $outcome, issue_number: $issue, spec_pr_number: $spec_pr}')
+          bash company/scripts/posthog-emit.sh goose_build_run "goose-build" "$PROPS"

--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -581,4 +581,4 @@ jobs:
             --arg issue "${ISSUE:-}" \
             --arg spec_pr "${SPEC_PR:-}" \
             '{outcome: $outcome, issue_number: $issue, spec_pr_number: $spec_pr}')
-          bash company/scripts/posthog-emit.sh goose_build_run "goose-build" "$PROPS"
+          bash company/scripts/posthog-emit.sh goose_build_run "goose-build" "$PROPS" || true

--- a/company/scripts/posthog-emit.sh
+++ b/company/scripts/posthog-emit.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Emit a single event to PostHog (server-side, write-only project key).
+# Non-fatal: failure prints ::warning:: and exits 0.
+#
+# Usage:
+#   posthog-emit.sh <event_name> [<distinct_id>] [<properties_json>]
+#
+# Env:
+#   POSTHOG_PROJECT_KEY  required; phc_... write-only project ingest key
+#   POSTHOG_HOST         optional; defaults to https://eu.i.posthog.com
+set -euo pipefail
+
+EVENT="${1:?event name required}"
+DISTINCT_ID="${2:-${GITHUB_REPOSITORY:-ai-pipeline-template}}"
+# Bash quirk: `${3:-{}}` corrupts a set value with an extra `}` because the
+# parser eats the inner `{}` as part of the default expression. Use explicit
+# branching so a passed JSON object stays intact.
+if [ "${3:-}" = "" ]; then
+  PROPS="{}"
+else
+  PROPS="$3"
+fi
+
+if [ -z "${POSTHOG_PROJECT_KEY:-}" ]; then
+  echo "::warning::POSTHOG_PROJECT_KEY unset, skipping event $EVENT"
+  exit 0
+fi
+
+# Inject standard properties: repo, run_id, run_url, workflow when available.
+# These match the GitHub Actions environment when invoked from a workflow step
+# and are harmlessly null when invoked from a local shell.
+STANDARD_PROPS=$(jq -nc \
+  --arg repo "${GITHUB_REPOSITORY:-}" \
+  --arg run_id "${GITHUB_RUN_ID:-}" \
+  --arg run_url "${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}" \
+  --arg workflow "${GITHUB_WORKFLOW:-}" \
+  --arg ref "${GITHUB_REF_NAME:-}" \
+  '{repo: $repo, run_id: $run_id, run_url: $run_url, workflow: $workflow, ref: $ref}')
+
+MERGED_PROPS=$(jq -nc --argjson std "$STANDARD_PROPS" --argjson custom "$PROPS" '$std + $custom')
+
+PAYLOAD=$(jq -nc \
+  --arg api_key "$POSTHOG_PROJECT_KEY" \
+  --arg event "$EVENT" \
+  --arg distinct_id "$DISTINCT_ID" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson props "$MERGED_PROPS" \
+  '{api_key: $api_key, event: $event, distinct_id: $distinct_id, timestamp: $ts, properties: $props}')
+
+URL="${POSTHOG_HOST:-https://eu.i.posthog.com}/i/v0/e/"
+
+curl --fail-with-body --silent --show-error --max-time 10 \
+  -X POST -H 'Content-Type: application/json' \
+  -d "$PAYLOAD" "$URL" \
+  >/dev/null \
+  || { code=$?; echo "::warning::posthog emit failed for event=$EVENT (curl exit $code, non-fatal)"; }

--- a/company/scripts/posthog-emit.sh
+++ b/company/scripts/posthog-emit.sh
@@ -8,10 +8,16 @@
 # Env:
 #   POSTHOG_PROJECT_KEY  required; phc_... write-only project ingest key
 #   POSTHOG_HOST         optional; defaults to https://eu.i.posthog.com
-set -euo pipefail
+#
+# Non-fatal contract: any failure inside this script must NOT break the
+# calling workflow step. Trap converts any non-zero exit (incl. jq parse
+# errors, missing tools, curl failures) into a ::warning:: + exit 0.
+set -u
+trap 'rc=$?; if [ "$rc" -ne 0 ]; then echo "::warning::posthog-emit.sh aborted (exit $rc, non-fatal)"; fi; exit 0' EXIT
+trap 'echo "::warning::posthog-emit.sh error at line $LINENO (non-fatal)"' ERR
 
 EVENT="${1:?event name required}"
-DISTINCT_ID="${2:-${GITHUB_REPOSITORY:-ai-pipeline-template}}"
+DISTINCT_ID="${2:-${GITHUB_REPOSITORY:-wgmesh}}"
 # Bash quirk: `${3:-{}}` corrupts a set value with an extra `}` because the
 # parser eats the inner `{}` as part of the default expression. Use explicit
 # branching so a passed JSON object stays intact.
@@ -52,5 +58,5 @@ URL="${POSTHOG_HOST:-https://eu.i.posthog.com}/i/v0/e/"
 curl --fail-with-body --silent --show-error --max-time 10 \
   -X POST -H 'Content-Type: application/json' \
   -d "$PAYLOAD" "$URL" \
-  >/dev/null \
-  || { code=$?; echo "::warning::posthog emit failed for event=$EVENT (curl exit $code, non-fatal)"; }
+  >/dev/null
+# Trap above handles any curl non-zero exit; no inline fallback needed.

--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -82,6 +82,18 @@ escalate() {
   fi
 
   log_audit "escalated" "$reason"
+
+  # Server-side PostHog event so escalation rate is queryable alongside
+  # bot_pr_merged. Non-fatal — the helper itself swallows curl failures.
+  if [ -x "${SCRIPT_DIR}/posthog-emit.sh" ]; then
+    local escalation_props
+    escalation_props=$(jq -nc \
+      --arg pr "$pr" \
+      --arg reason "$safe_reason" \
+      '{pr_number: ($pr|tonumber), reason: $reason}')
+    bash "${SCRIPT_DIR}/posthog-emit.sh" escalation_posted "pr-review-merge" "$escalation_props" || true
+  fi
+
   check_circuit_breaker
 }
 

--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -85,7 +85,7 @@ escalate() {
 
   # Server-side PostHog event so escalation rate is queryable alongside
   # bot_pr_merged. Non-fatal — the helper itself swallows curl failures.
-  if [ -x "${SCRIPT_DIR}/posthog-emit.sh" ]; then
+  if [ -f "${SCRIPT_DIR}/posthog-emit.sh" ]; then
     local escalation_props
     escalation_props=$(jq -nc \
       --arg pr "$pr" \


### PR DESCRIPTION
## Summary

Mirrors the pattern from `atvirokodosprendimai/ai-pipeline-template` PRs #712 + #713 into wgmesh. Server-side curl-based event emit to PostHog EU; project key + host inherited from org-level secret + variable (`POSTHOG_PROJECT_KEY` + `POSTHOG_HOST`).

## What

- **New helper:** `company/scripts/posthog-emit.sh`. Builds payload with standard properties (repo, run_id, run_url, workflow, ref) merged with caller-supplied custom properties. POSTs to `${POSTHOG_HOST}/i/v0/e/`. Non-fatal on failure (`::warning::` only).
- **Wired emits:**

| Event | Location | Triggered when | Props |
|---|---|---|---|
| `bot_pr_merged` | `bot-pr-review-merge.yml` | every autonomous-reviewed PR | outcome, pr_number, author, title |
| `escalation_posted` | `pr-review-merge.sh` `escalate()` | every escalation comment | pr_number, reason |
| `goose_build_run` | `goose-build.yml` | every Goose build attempt | outcome, issue_number, spec_pr_number |

- **Branch-restore in goose-build.yml:** Goose creates implementation branches mid-job that may predate this script, so the emit step prepends `git checkout main -- company/scripts/posthog-emit.sh 2>/dev/null || true` before invoking. Same pattern that ai-pipeline-template's PR #713 introduced.
- **bot-pr-review-merge.yml is exempt** — it explicitly checks out `main` for the script step.

## Out of scope

- **PUSH_TOKEN → App token migration** for wgmesh (separate, larger work; ai-pipeline-template did this in PR #675)
- **PostHog dashboards / saved insights** (UI work)
- **Other workflows** (release.yml, docker-build.yml, hetzner-integration.yml, terraform). These can be added once the pattern is proven here.

## Test plan

- [ ] Org-level `POSTHOG_PROJECT_KEY` secret promoted (in progress)
- [ ] Merge
- [ ] Wait for next bot-authored PR auto-merge — verify `bot_pr_merged` event lands in PostHog EU
- [ ] Trigger Goose build manually via `workflow_dispatch` — verify `goose_build_run` event lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)