### PR TITLE
fix(process): require reporter verification before closing bug-class issues

### DIFF
--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -1,5 +1,21 @@
 name: Implementation Merged — Close Issue
 
+# When an `impl: Issue #N - ...` PR merges, this workflow decides whether to
+# close the linked issue or send it to verification limbo.
+#
+# Process bug (2026-04-29): wgmesh#540 was auto-closed when PR #544 merged,
+# but the PR fixed only one of two affected code paths. The user re-reported
+# the same bug 6 days later. "Linked PR merged" is necessary but not
+# sufficient signal for closing bug-class issues.
+#
+# Policy:
+#   - issue carries `type: bug` (or `bug`) label → do NOT close. Add
+#     `awaiting-verification` label, post a comment asking the author to
+#     confirm the fix on their reproduction. Close on author confirmation
+#     (separate workflow / future manual action), reopen on author rebuttal.
+#   - issue does not carry a bug label (feature, chore, docs) → auto-close
+#     as before. Tests structurally validate non-bug work.
+
 on:
   pull_request:
     types: [closed]
@@ -17,7 +33,17 @@ jobs:
       !contains(github.event.pull_request.title, 'loop:')
     runs-on: ubuntu-latest
     steps:
-      - name: Close linked issue
+      - name: Ensure awaiting-verification label exists
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          gh label create awaiting-verification \
+            --repo "${{ github.repository }}" \
+            --description "Bug fix merged; awaiting reporter confirmation before close" \
+            --color FBCA04 \
+            --force 2>/dev/null || true
+
+      - name: Close linked issue or send to verification
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PUSH_TOKEN }}
@@ -28,13 +54,72 @@ jobs:
 
             const issueNumber = parseInt(issueMatch[1], 10);
 
+            // Fetch issue to inspect labels + author.
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+
+            const labelNames = issue.labels.map(l => typeof l === 'string' ? l : l.name);
+            const isBug = labelNames.some(n => n === 'type: bug' || n === 'bug');
+
+            if (isBug) {
+              core.info(`Issue #${issueNumber} carries bug label; awaiting reporter verification.`);
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['awaiting-verification']
+              });
+
+              for (const stale of ['copilot-triaging', 'needs-triage']) {
+                if (labelNames.includes(stale)) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issueNumber,
+                      name: stale
+                    });
+                  } catch (e) {
+                    core.warning(`Failed to remove ${stale} label: ${e.message}`);
+                  }
+                }
+              }
+
+              const author = issue.user && issue.user.login ? `@${issue.user.login}` : 'reporter';
+              const body = [
+                `Implementation for this bug merged in PR #${pr.number}.`,
+                ``,
+                `${author}, please verify the fix against your original reproduction and reply with one of:`,
+                ``,
+                `- **\`verified\`** / **\`confirmed\`** / **\`fixed\`** if the bug no longer reproduces — the issue will be closed.`,
+                `- **\`still broken\`** / **\`not fixed\`** with details if the bug still reproduces — the issue stays open and we'll ship a follow-up.`,
+                ``,
+                `_Auto-close was deliberately disabled for \`type: bug\` issues after wgmesh#540 was closed prematurely on a partial fix. See the impl-merged-close.yml header for the policy._`
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body
+              });
+              return;
+            }
+
             await github.rest.issues.update({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: issueNumber, state: 'closed'
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              state: 'closed'
             });
 
             await github.rest.issues.createComment({
-              owner: context.repo.owner, repo: context.repo.repo,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               issue_number: issueNumber,
               body: `Resolved by PR #${pr.number}. Implementation merged to main.`
             });

--- a/.github/workflows/verify-comment-close.yml
+++ b/.github/workflows/verify-comment-close.yml
@@ -1,0 +1,87 @@
+name: Verify Comment — Close Awaiting Verification
+
+# Companion to impl-merged-close.yml. When an issue is in
+# `awaiting-verification` state (bug fix merged but not yet confirmed), the
+# original reporter can close it by replying with one of:
+#   verified | confirmed | fixed | works | resolved
+#
+# Only the issue's original author can trigger the close. Other commenters
+# saying "verified" do not count — the bug reporter is the only one who
+# knows whether their reproduction stopped reproducing.
+#
+# Policy mate of `Implementation Merged — Close Issue`. Together they form:
+#   merge → awaiting-verification → author confirms → closed
+# instead of the previous over-eager `merge → closed`.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  close-on-verify:
+    # Only on issues (not PRs) that carry the awaiting-verification label.
+    # The if expression cannot inspect labels directly without an API call,
+    # so we do that in the script step and exit early when not applicable.
+    if: >-
+      github.event.issue.pull_request == null &&
+      github.event.comment.user.login == github.event.issue.user.login
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issue when author confirms fix
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.PUSH_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+
+            const labelNames = issue.labels.map(l => typeof l === 'string' ? l : l.name);
+            if (!labelNames.includes('awaiting-verification')) {
+              core.info(`Issue #${issue.number} not in awaiting-verification state; ignoring.`);
+              return;
+            }
+
+            // Match a verification phrase. Word-boundaries to avoid false
+            // positives like "this is not verified" — the leading-negation
+            // case is harder than this regex covers, so we keep the
+            // negation patterns as a separate skip.
+            const body = (comment.body || '').toLowerCase();
+            const negation = /\b(not|isn'?t|still)\s+(verified|confirmed|fixed|working|resolved)\b/;
+            const positive = /\b(verified|confirmed|fixed|works|works for me|wfm|resolved)\b/;
+
+            if (negation.test(body)) {
+              core.info(`Comment on #${issue.number} contains negation; not closing.`);
+              return;
+            }
+            if (!positive.test(body)) {
+              core.info(`Comment on #${issue.number} did not match a verification phrase.`);
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed'
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: 'awaiting-verification'
+              });
+            } catch (e) {
+              core.warning(`Failed to remove awaiting-verification label: ${e.message}`);
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `Closed: reporter confirmed fix in [comment](${comment.html_url}). Thanks for verifying.`
+            });


### PR DESCRIPTION
## Process bug

Issue #540 ("[Bug] key rotation changes node IP address") was auto-closed 2026-04-29 when PR #544 merged. Today (2026-05-05), 6 days later, the reporter confirms the bug still reproduces:

> wgmesh config'e vis dar nesaugo IP adreso, but seems that issue is closed

Investigation found PR #544 fixed only `pkg/daemon/daemon.go::initLocalNode`. The service-registration path `service.go::deriveMeshIPForService` has two separate bugs:

1. **JSON field-name mismatch** — daemon writes `wg_pubkey`, service reads `public_key`. Service silently falls to the `"unjoined"` placeholder branch every time.
2. **Service ignores persisted MeshIP** — re-derives from `pubkey + current_secret` instead of reading `mesh_ip` field that PR #544 added.

The implementation was incomplete. The autonomous pipeline closed the issue anyway because `impl-merged-close.yml` closes any `impl: Issue #N - ...` PR's linked issue on merge, with zero verification.

## Fix

This PR changes the close policy. Code bug (service.go) is **out of scope here** — that lands in a follow-up PR.

`impl-merged-close.yml`:
- Inspects the linked issue's labels.
- If `type: bug` (or bare `bug`) is present → do NOT close. Add `awaiting-verification` label, remove `copilot-triaging` / `needs-triage`, post comment asking reporter to confirm.
- Otherwise → auto-close as before.

New `verify-comment-close.yml`:
- Triggers on `issue_comment` events.
- Closes the issue when the original reporter (author == comment author) replies with a verification phrase: `verified`, `confirmed`, `fixed`, `works`, `resolved`.
- Negation matcher prevents "still not fixed" / "isn't verified" from triggering close.

## Why not auto-close non-bug issues

Features, chores, docs are typically structurally validated by tests. The reporter doesn't have a personal reproduction to confirm against. Auto-close on merge is fine for those.

## Trade-offs

- Bug fixes now spend time in `awaiting-verification` state. Reporters who never return mean some issues linger. Acceptable vs. false-positive closes that erode trust.
- Future enhancement (separate PR): scheduled workflow that pings reporter after 7 days, auto-closes after 30 days of silence.

## Test plan

- [ ] Merge
- [ ] Reopen #540 (separate manual action, or in the follow-up service.go PR)
- [ ] Ship the service.go fix as `impl: Issue #540 - ...` follow-up PR
- [ ] When that follow-up merges, this workflow should add `awaiting-verification` instead of closing
- [ ] Reporter replies "verified" → verify-comment-close.yml closes it

## Followups (separate PR)

- service.go::deriveMeshIPForService: read `wg_pubkey` field (not `public_key`), prefer persisted `mesh_ip` over re-derive
- Test exercising full flow: `wgmesh join --secret X` → rotate to `Y` → `wgmesh service register ...` → confirm IP unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)