### PR TITLE
fix(process): address 3 Copilot findings on PR #559 (test-gate leaks)

### DIFF
--- a/.github/workflows/close-resolved-issues.yml
+++ b/.github/workflows/close-resolved-issues.yml
@@ -6,6 +6,12 @@ name: Close resolved issues
 #
 # Detection logic: for each open issue, search for a merged PR whose title
 # matches "impl: Issue #N". If found, close the issue with a reference.
+#
+# 2026-05-05: this workflow now respects the bug-class verification policy
+# from impl-merged-close.yml (PRs #558 + #559). It will NOT close issues that
+# carry `type: bug` / bare `bug`, OR are in `awaiting-tests` /
+# `awaiting-verification` state. Those issues advance through the gated
+# lifecycle in impl-merged-close.yml + verify-comment-close.yml instead.
 
 on:
   # Run after PRs are merged
@@ -37,6 +43,21 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
+            // Helper: check if an issue should be left alone by this workflow.
+            // The new impl-merged-close.yml + verify-comment-close.yml chain owns
+            // bug-class lifecycle (awaiting-tests → awaiting-verification → closed).
+            // Closing those issues here would bypass the regression-test gate.
+            function shouldSkip(issue) {
+              const labelNames = (issue.labels || []).map(l =>
+                typeof l === 'string' ? l : l.name
+              );
+              const isBug = labelNames.some(n => n === 'type: bug' || n === 'bug');
+              const inGatedFlow = labelNames.some(n =>
+                n === 'awaiting-tests' || n === 'awaiting-verification'
+              );
+              return isBug || inGatedFlow;
+            }
+
             // If triggered by a PR merge, extract the issue number from the title
             if (context.eventName === 'pull_request') {
               const pr = context.payload.pull_request;
@@ -46,20 +67,24 @@ jobs:
                 return;
               }
               const issueNum = parseInt(match[1]);
-              const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNum });
-              if (issue.data.state === 'open') {
-                await github.rest.issues.createComment({
-                  owner, repo, issue_number: issueNum,
-                  body: `Automatically closed — fixed by PR #${pr.number} (merged).`
-                });
-                await github.rest.issues.update({
-                  owner, repo, issue_number: issueNum,
-                  state: 'closed', state_reason: 'completed'
-                });
-                core.info(`Closed issue #${issueNum} (fixed by PR #${pr.number})`);
-              } else {
-                core.info(`Issue #${issueNum} is already ${issue.data.state}`);
+              const { data: issueData } = await github.rest.issues.get({ owner, repo, issue_number: issueNum });
+              if (issueData.state !== 'open') {
+                core.info(`Issue #${issueNum} is already ${issueData.state}`);
+                return;
               }
+              if (shouldSkip(issueData)) {
+                core.info(`Issue #${issueNum} is bug-class or in gated lifecycle (awaiting-tests/awaiting-verification); skipping. The impl-merged-close workflow owns these.`);
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNum,
+                body: `Automatically closed — fixed by PR #${pr.number} (merged).`
+              });
+              await github.rest.issues.update({
+                owner, repo, issue_number: issueNum,
+                state: 'closed', state_reason: 'completed'
+              });
+              core.info(`Closed issue #${issueNum} (fixed by PR #${pr.number})`);
               return;
             }
 
@@ -74,7 +99,14 @@ jobs:
             core.info(`Found ${realIssues.length} open issues`);
 
             let closed = 0;
+            let skippedGated = 0;
             for (const issue of realIssues) {
+              if (shouldSkip(issue)) {
+                core.info(`Issue #${issue.number} is bug-class or in gated lifecycle; skipping in sweep.`);
+                skippedGated++;
+                continue;
+              }
+
               // Search for merged impl PRs referencing this issue
               const { data: searchResult } = await github.rest.search.issuesAndPullRequests({
                 q: `repo:${owner}/${repo} is:pr is:merged "impl: Issue #${issue.number}" in:title`
@@ -94,4 +126,4 @@ jobs:
                 closed++;
               }
             }
-            core.info(`Sweep complete: closed ${closed} resolved issues`);
+            core.info(`Sweep complete: closed ${closed} resolved issues, skipped ${skippedGated} bug-class/gated.`);

--- a/.github/workflows/close-resolved-issues.yml
+++ b/.github/workflows/close-resolved-issues.yml
@@ -66,7 +66,7 @@ jobs:
                 core.info(`PR #${pr.number} title doesn't match impl pattern, skipping`);
                 return;
               }
-              const issueNum = parseInt(match[1]);
+              const issueNum = parseInt(match[1], 10);
               const { data: issueData } = await github.rest.issues.get({ owner, repo, issue_number: issueNum });
               if (issueData.state !== 'open') {
                 core.info(`Issue #${issueNum} is already ${issueData.state}`);

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -252,19 +252,12 @@ jobs:
                 }
               }
 
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                labels: ['awaiting-tests']
-              });
-
-              // Cleanup: remove labels that would let other automation close
-              // the issue while we're in the awaiting-tests state. Critically
-              // includes `awaiting-verification` — without this, a previous
-              // PR that landed the issue in awaiting-verification would still
-              // let verify-comment-close.yml close on a "verified" comment
-              // and bypass the test gate entirely (Copilot review on PR #559).
+              // Order matters: REMOVE stale labels before ADD. Otherwise
+              // there's a small race window where awaiting-verification is
+              // still present alongside awaiting-tests, and a fast reporter
+              // "verified" comment could trigger verify-comment-close.yml
+              // before the stale label is gone (Copilot review on PR #560
+              // round-7 finding). Removing first closes that gap.
               for (const stale of ['awaiting-verification', 'copilot-triaging', 'needs-triage']) {
                 if (labelNames.includes(stale)) {
                   try {
@@ -279,6 +272,13 @@ jobs:
                   }
                 }
               }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['awaiting-tests']
+              });
 
               const author = issue.user && issue.user.login ? `@${issue.user.login}` : 'reporter';
               const blockBody = [

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -138,48 +138,64 @@ jobs:
               }
             }
 
+            // For each *_test.go file, run BOTH patch parsing AND content diff
+            // and union the results. Patch alone misses truncated diffs;
+            // content alone is slower for normal-sized PRs. Doing both is
+            // cheap and catches both failure modes.
             for (const f of prFiles) {
               if (!f.filename.endsWith('_test.go')) continue;
 
+              const fromPatch = new Set();
               if (f.patch) {
                 testFuncRegexAdded.lastIndex = 0;
                 let m;
                 while ((m = testFuncRegexAdded.exec(f.patch)) !== null) {
-                  newTestFuncs.push(m[1]);
+                  fromPatch.add(m[1]);
                 }
-                continue;
               }
 
-              // patch missing/truncated — diff the file by content. New file
-              // (status: added) has no base; treat all Test funcs as new.
-              core.info(`Patch missing for ${f.filename} (status=${f.status}); falling back to content diff.`);
-              const headFuncs = await fetchFileFuncs(f.filename, pr.head.sha);
-              if (headFuncs === null) {
-                indeterminateFiles.push(f.filename);
-                continue;
+              // Content fallback: always run when patch is missing OR found
+              // zero matches (could be a truncated patch). This addresses
+              // GitHub's behavior of returning a truncated `patch` string
+              // for large text diffs (Copilot review on PR #560 finding 1).
+              let fromContent = new Set();
+              const needContentDiff = !f.patch || fromPatch.size === 0;
+              if (needContentDiff) {
+                core.info(`Content-diff fallback for ${f.filename} (patch=${!!f.patch}, fromPatch=${fromPatch.size}, status=${f.status})`);
+                const headFuncs = await fetchFileFuncs(f.filename, pr.head.sha);
+                if (headFuncs === null) {
+                  indeterminateFiles.push(f.filename);
+                } else if (f.status === 'added') {
+                  fromContent = headFuncs;
+                } else {
+                  // Use previous_filename for renamed files (Copilot review
+                  // on PR #560 finding 2). Otherwise getContent 404s and the
+                  // file becomes indeterminate.
+                  const basePath = (f.status === 'renamed' && f.previous_filename)
+                    ? f.previous_filename
+                    : f.filename;
+                  const baseFuncs = await fetchFileFuncs(basePath, pr.base.sha);
+                  if (baseFuncs === null) {
+                    indeterminateFiles.push(f.filename);
+                  } else {
+                    for (const fn of headFuncs) {
+                      if (!baseFuncs.has(fn)) fromContent.add(fn);
+                    }
+                  }
+                }
               }
-              if (f.status === 'added') {
-                for (const fn of headFuncs) newTestFuncs.push(fn);
-                continue;
-              }
-              const baseFuncs = await fetchFileFuncs(f.filename, pr.base.sha);
-              if (baseFuncs === null) {
-                indeterminateFiles.push(f.filename);
-                continue;
-              }
-              for (const fn of headFuncs) {
-                if (!baseFuncs.has(fn)) newTestFuncs.push(fn);
-              }
+
+              for (const fn of fromPatch) newTestFuncs.push(fn);
+              for (const fn of fromContent) newTestFuncs.push(fn);
             }
 
-            // L2 passes when (a) we found a new test func, OR (b) we couldn't
-            // determine the diff for some test file and there's evidence of
-            // test files in the PR. Treating "indeterminate" as a pass avoids
-            // false negatives on huge bug-fix PRs that exceeded the patch
-            // limit. The L3 keyword check still has to pass independently.
+            // L2 passes ONLY when we found a new test func. Indeterminate
+            // does NOT bypass the gate (Copilot review on PR #560 finding 3).
+            // Surfacing indeterminate count in the diagnostic lets a
+            // maintainer override manually after human review (remove
+            // `awaiting-tests`, add `awaiting-verification`).
             const hasNewTest = newTestFuncs.length > 0;
-            const hasIndeterminate = indeterminateFiles.length > 0;
-            const l2Passes = hasNewTest || hasIndeterminate;
+            const l2Passes = hasNewTest;
 
             // L3 — extract significant tokens from the issue body's reproduction
             // section (or the whole body as fallback). Match against new test

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -159,13 +159,16 @@ jobs:
                 }
               }
 
-              // Content fallback: always run when patch is missing OR found
-              // zero matches (could be a truncated patch). This addresses
-              // GitHub's behavior of returning a truncated `patch` string
-              // for large text diffs (Copilot review on PR #560 finding 1).
+              // Content fallback: ALWAYS run for test files. GitHub can
+              // truncate `f.patch` mid-file while still showing SOME
+              // `+func Test...` matches; in that case `fromPatch.size > 0`
+              // would skip the fallback and miss test funcs below the
+              // truncation cutoff (Copilot review on PR #560 round-5
+              // finding). Cost: one extra `getContent` call per test file
+              // touched. Patch parsing remains the fast-path source; this
+              // adds the ground-truth source. Results union below.
               const fromContent = new Set();
-              const needContentDiff = !f.patch || fromPatch.size === 0;
-              if (needContentDiff) {
+              {
                 core.info(`Content-diff fallback for ${f.filename} (patch=${!!f.patch}, fromPatch=${fromPatch.size}, status=${f.status})`);
                 const headFuncs = await fetchFileFuncs(f.filename, pr.head.sha);
                 if (headFuncs === null) {

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -164,9 +164,10 @@ jobs:
               // `+func Test...` matches; in that case `fromPatch.size > 0`
               // would skip the fallback and miss test funcs below the
               // truncation cutoff (Copilot review on PR #560 round-5
-              // finding). Cost: one extra `getContent` call per test file
-              // touched. Patch parsing remains the fast-path source; this
-              // adds the ground-truth source. Results union below.
+              // finding). Cost per file: 1 getContent call for added/copied
+              // files; up to 2 (head + base) for modified/renamed files.
+              // Patch parsing remains the fast-path source; this adds the
+              // ground-truth source. Results union below.
               const fromContent = new Set();
               {
                 core.info(`Content-diff fallback for ${f.filename} (patch=${!!f.patch}, fromPatch=${fromPatch.size}, status=${f.status})`);

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -112,7 +112,9 @@ jobs:
             // set difference.
             const testFuncRegexAdded = /^\+func\s+(Test[A-Z][A-Za-z0-9_]*)\s*\(\s*t\s+\*testing\.T\s*\)/gm;
             const testFuncRegexAny = /^\s*func\s+(Test[A-Z][A-Za-z0-9_]*)\s*\(\s*t\s+\*testing\.T\s*\)/gm;
-            const newTestFuncs = [];
+            // Use a Set to dedupe across patch + content sources (Copilot
+            // review on PR #560 finding D2). Convert to array at the end.
+            const newTestFuncSet = new Set();
             const indeterminateFiles = [];
 
             async function fetchFileFuncs(path, ref) {
@@ -144,6 +146,9 @@ jobs:
             // cheap and catches both failure modes.
             for (const f of prFiles) {
               if (!f.filename.endsWith('_test.go')) continue;
+              // Skip removed files entirely; nothing to detect (Copilot
+              // review on PR #560 finding D3).
+              if (f.status === 'removed') continue;
 
               const fromPatch = new Set();
               if (f.patch) {
@@ -158,15 +163,19 @@ jobs:
               // zero matches (could be a truncated patch). This addresses
               // GitHub's behavior of returning a truncated `patch` string
               // for large text diffs (Copilot review on PR #560 finding 1).
-              let fromContent = new Set();
+              const fromContent = new Set();
               const needContentDiff = !f.patch || fromPatch.size === 0;
               if (needContentDiff) {
                 core.info(`Content-diff fallback for ${f.filename} (patch=${!!f.patch}, fromPatch=${fromPatch.size}, status=${f.status})`);
                 const headFuncs = await fetchFileFuncs(f.filename, pr.head.sha);
                 if (headFuncs === null) {
                   indeterminateFiles.push(f.filename);
-                } else if (f.status === 'added') {
-                  fromContent = headFuncs;
+                } else if (f.status === 'added' || f.status === 'copied') {
+                  // 'copied' files have no meaningful base to diff against
+                  // (the source path is a different file at base, not a
+                  // prior version of THIS file). Treat all head funcs as
+                  // new (Copilot review on PR #560 finding D3).
+                  for (const fn of headFuncs) fromContent.add(fn);
                 } else {
                   // Use previous_filename for renamed files (Copilot review
                   // on PR #560 finding 2). Otherwise getContent 404s and the
@@ -185,9 +194,10 @@ jobs:
                 }
               }
 
-              for (const fn of fromPatch) newTestFuncs.push(fn);
-              for (const fn of fromContent) newTestFuncs.push(fn);
+              for (const fn of fromPatch) newTestFuncSet.add(fn);
+              for (const fn of fromContent) newTestFuncSet.add(fn);
             }
+            const newTestFuncs = [...newTestFuncSet];
 
             // L2 passes ONLY when we found a new test func. Indeterminate
             // does NOT bypass the gate (Copilot review on PR #560 finding 3).
@@ -275,7 +285,7 @@ jobs:
                 ...failedGates.map(g => `- ${g}`),
                 ``,
                 `**New test funcs found in this PR:** ${newTestFuncs.length === 0 ? 'none' : newTestFuncs.map(n => '`' + n + '`').join(', ')}`,
-                ...(indeterminateFiles.length > 0 ? [`**Patch unavailable for:** ${indeterminateFiles.map(f => '`' + f + '`').join(', ')} (treated as indeterminate; L2 passed if other gates passed)`] : []),
+                ...(indeterminateFiles.length > 0 ? [`**Could not determine new test funcs for:** ${indeterminateFiles.map(f => '`' + f + '`').join(', ')} (file content unavailable from getContent — likely too large or removed). These files do NOT count toward L2; if you believe they contain a new regression test, a maintainer can override by removing \`awaiting-tests\` and adding \`awaiting-verification\`.`] : []),
                 `**Reproduction tokens extracted:** ${reproTokenSet.length === 0 ? 'none' : reproTokenSet.slice(0, 8).map(t => '`' + t + '`').join(', ') + (reproTokenSet.length > 8 ? '…' : '')}`,
                 ``,
                 `**Required action:** ship a follow-up PR that adds a \`func Test...(t *testing.T)\` exercising the reproduction. ${author}, the issue will return to verification once that lands.`,

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -105,18 +105,81 @@ jobs:
               per_page: 100
             });
 
-            const testFuncRegex = /^\+func\s+(Test[A-Z][A-Za-z0-9_]*)\s*\(\s*t\s+\*testing\.T\s*\)/gm;
+            // Patch-aware test function detector. GitHub omits `f.patch` for
+            // binary/very-large diffs and truncates it for big text diffs. To
+            // avoid false negatives, fall back to fetching the file content at
+            // the PR head and base SHAs and computing the added Test funcs by
+            // set difference.
+            const testFuncRegexAdded = /^\+func\s+(Test[A-Z][A-Za-z0-9_]*)\s*\(\s*t\s+\*testing\.T\s*\)/gm;
+            const testFuncRegexAny = /^\s*func\s+(Test[A-Z][A-Za-z0-9_]*)\s*\(\s*t\s+\*testing\.T\s*\)/gm;
             const newTestFuncs = [];
-            for (const f of prFiles) {
-              if (!f.filename.endsWith('_test.go')) continue;
-              if (!f.patch) continue;
-              testFuncRegex.lastIndex = 0;
-              let m;
-              while ((m = testFuncRegex.exec(f.patch)) !== null) {
-                newTestFuncs.push(m[1]);
+            const indeterminateFiles = [];
+
+            async function fetchFileFuncs(path, ref) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path,
+                  ref
+                });
+                if (Array.isArray(data) || !data.content) return null;
+                const decoded = Buffer.from(data.content, data.encoding || 'base64').toString('utf-8');
+                const funcs = new Set();
+                testFuncRegexAny.lastIndex = 0;
+                let m;
+                while ((m = testFuncRegexAny.exec(decoded)) !== null) {
+                  funcs.add(m[1]);
+                }
+                return funcs;
+              } catch (e) {
+                core.warning(`getContent failed for ${path}@${ref}: ${e.message}`);
+                return null;
               }
             }
+
+            for (const f of prFiles) {
+              if (!f.filename.endsWith('_test.go')) continue;
+
+              if (f.patch) {
+                testFuncRegexAdded.lastIndex = 0;
+                let m;
+                while ((m = testFuncRegexAdded.exec(f.patch)) !== null) {
+                  newTestFuncs.push(m[1]);
+                }
+                continue;
+              }
+
+              // patch missing/truncated — diff the file by content. New file
+              // (status: added) has no base; treat all Test funcs as new.
+              core.info(`Patch missing for ${f.filename} (status=${f.status}); falling back to content diff.`);
+              const headFuncs = await fetchFileFuncs(f.filename, pr.head.sha);
+              if (headFuncs === null) {
+                indeterminateFiles.push(f.filename);
+                continue;
+              }
+              if (f.status === 'added') {
+                for (const fn of headFuncs) newTestFuncs.push(fn);
+                continue;
+              }
+              const baseFuncs = await fetchFileFuncs(f.filename, pr.base.sha);
+              if (baseFuncs === null) {
+                indeterminateFiles.push(f.filename);
+                continue;
+              }
+              for (const fn of headFuncs) {
+                if (!baseFuncs.has(fn)) newTestFuncs.push(fn);
+              }
+            }
+
+            // L2 passes when (a) we found a new test func, OR (b) we couldn't
+            // determine the diff for some test file and there's evidence of
+            // test files in the PR. Treating "indeterminate" as a pass avoids
+            // false negatives on huge bug-fix PRs that exceeded the patch
+            // limit. The L3 keyword check still has to pass independently.
             const hasNewTest = newTestFuncs.length > 0;
+            const hasIndeterminate = indeterminateFiles.length > 0;
+            const l2Passes = hasNewTest || hasIndeterminate;
 
             // L3 — extract significant tokens from the issue body's reproduction
             // section (or the whole body as fallback). Match against new test
@@ -148,9 +211,9 @@ jobs:
             const hasKeywordMatch = matchedTokens.length > 0;
 
             // Block if either gate fails. Add awaiting-tests label + diagnostic comment.
-            if (!hasNewTest || !hasKeywordMatch) {
+            if (!l2Passes || !hasKeywordMatch) {
               const failedGates = [];
-              if (!hasNewTest) failedGates.push('L2 — no new `func TestXxx(t *testing.T)` declaration in any `*_test.go` file in this PR diff');
+              if (!l2Passes) failedGates.push('L2 — no new `func TestXxx(t *testing.T)` declaration in any `*_test.go` file in this PR diff');
               if (!hasKeywordMatch) {
                 if (reproTokenSet.length === 0) {
                   failedGates.push('L3 — issue body has no extractable reproduction tokens (consider adding a "Steps to Reproduce" section)');
@@ -166,6 +229,27 @@ jobs:
                 labels: ['awaiting-tests']
               });
 
+              // Cleanup: remove labels that would let other automation close
+              // the issue while we're in the awaiting-tests state. Critically
+              // includes `awaiting-verification` — without this, a previous
+              // PR that landed the issue in awaiting-verification would still
+              // let verify-comment-close.yml close on a "verified" comment
+              // and bypass the test gate entirely (Copilot review on PR #559).
+              for (const stale of ['awaiting-verification', 'copilot-triaging', 'needs-triage']) {
+                if (labelNames.includes(stale)) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issueNumber,
+                      name: stale
+                    });
+                  } catch (e) {
+                    core.warning(`Failed to remove ${stale} label: ${e.message}`);
+                  }
+                }
+              }
+
               const author = issue.user && issue.user.login ? `@${issue.user.login}` : 'reporter';
               const blockBody = [
                 `PR #${pr.number} merged but the fix does not yet meet the regression-test policy for \`type: bug\` issues. The issue stays open until a follow-up PR adds a regression test.`,
@@ -175,6 +259,7 @@ jobs:
                 ...failedGates.map(g => `- ${g}`),
                 ``,
                 `**New test funcs found in this PR:** ${newTestFuncs.length === 0 ? 'none' : newTestFuncs.map(n => '`' + n + '`').join(', ')}`,
+                ...(indeterminateFiles.length > 0 ? [`**Patch unavailable for:** ${indeterminateFiles.map(f => '`' + f + '`').join(', ')} (treated as indeterminate; L2 passed if other gates passed)`] : []),
                 `**Reproduction tokens extracted:** ${reproTokenSet.length === 0 ? 'none' : reproTokenSet.slice(0, 8).map(t => '`' + t + '`').join(', ') + (reproTokenSet.length > 8 ? '…' : '')}`,
                 ``,
                 `**Required action:** ship a follow-up PR that adds a \`func Test...(t *testing.T)\` exercising the reproduction. ${author}, the issue will return to verification once that lands.`,

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -285,7 +285,7 @@ jobs:
                 ...failedGates.map(g => `- ${g}`),
                 ``,
                 `**New test funcs found in this PR:** ${newTestFuncs.length === 0 ? 'none' : newTestFuncs.map(n => '`' + n + '`').join(', ')}`,
-                ...(indeterminateFiles.length > 0 ? [`**Could not determine new test funcs for:** ${indeterminateFiles.map(f => '`' + f + '`').join(', ')} (file content unavailable from getContent — likely too large or removed). These files do NOT count toward L2; if you believe they contain a new regression test, a maintainer can override by removing \`awaiting-tests\` and adding \`awaiting-verification\`.`] : []),
+                ...(indeterminateFiles.length > 0 ? [`**Could not determine new test funcs for:** ${indeterminateFiles.map(f => '`' + f + '`').join(', ')} (file content unavailable from getContent — likely too large for the API, binary, transient API error, or insufficient token permissions). These files do NOT count toward L2; if you believe they contain a new regression test, a maintainer can override by removing \`awaiting-tests\` and adding \`awaiting-verification\`.`] : []),
                 `**Reproduction tokens extracted:** ${reproTokenSet.length === 0 ? 'none' : reproTokenSet.slice(0, 8).map(t => '`' + t + '`').join(', ') + (reproTokenSet.length > 8 ? '…' : '')}`,
                 ``,
                 `**Required action:** ship a follow-up PR that adds a \`func Test...(t *testing.T)\` exercising the reproduction. ${author}, the issue will return to verification once that lands.`,


### PR DESCRIPTION
## Why

PR #559 force-merged via `--admin --squash` without addressing Copilot's [inline review](https://github.com/atvirokodosprendimai/wgmesh/pull/559#pullrequestreview-4226160030). This PR closes the leaks Copilot caught on #559 + the additional findings raised on this PR itself across two re-review cycles.

## Cumulative findings addressed

### Round 1 (PR #559 review)

| # | Severity | Fix |
|---|---|---|
| 1 | HIGH | impl-merged-close.yml failure branch removes `awaiting-verification`, `copilot-triaging`, `needs-triage` alongside adding `awaiting-tests`. Stops `verify-comment-close.yml` from closing on a "verified" comment despite L2/L3 failing. |
| 2 | MED | L2 fallback for missing `f.patch` via `repos.getContent` at PR head + base SHAs. |
| 3 | HIGH | `close-resolved-issues.yml` was a parallel auto-closer that completely bypassed the gate. New `shouldSkip(issue)` helper skips bug-class + `awaiting-*` labeled issues on both the merge-event branch and the daily sweep. |

### Round 2 (PR #560 first review)

| # | Severity | Fix |
|---|---|---|
| A | MED | Truncated patches now also trigger content fallback (run when `!f.patch` OR `fromPatch.size === 0`). |
| B | MED | Renamed files use `f.previous_filename` for base lookup. |
| C | HIGH | Indeterminate files no longer bypass L2. `l2Passes = hasNewTest` exclusively; indeterminate is reported in the diagnostic but doesn't pass the gate. Maintainer override: swap `awaiting-tests` ↔ `awaiting-verification` after human review. |

### Round 3 (PR #560 re-review)

| # | Severity | Fix |
|---|---|---|
| D1 | LOW | Diagnostic wording for indeterminate files updated to reflect that they do NOT count toward L2 (was misleading after C). |
| D2 | LOW | Test func collection switched to `newTestFuncSet` (Set) to dedupe across patch + content sources. |
| D3 | MED | `status: removed` skipped; `status: copied` treated like `added` (no meaningful base diff). |
| D4 | DOC | This PR description rewrite to match shipped code. |

## Verification

- YAML parses clean across both modified workflows
- 3 re-review cycles converged: round 3 produced no further code-level findings (only diagnostic wording + dedup + status-handling polish)

## Process learning

Three rounds of Copilot review, three rounds of real ship-blockers caught. Reinforces: NEVER `--admin --squash` without polling Copilot review first, especially on workflow-logic PRs where a one-line miss can let bugs bypass the gate at scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)