### PR TITLE
fix(workflows): pull_request_target on closed-event family (#79)

### DIFF
--- a/.github/workflows/close-resolved-issues.yml
+++ b/.github/workflows/close-resolved-issues.yml
@@ -14,8 +14,11 @@ name: Close resolved issues
 # lifecycle in impl-merged-close.yml + verify-comment-close.yml instead.
 
 on:
-  # Run after PRs are merged
-  pull_request:
+  # pull_request_target so Copilot-coding-agent `copilot/*` PRs do not
+  # freeze the run in `action_required` during their draft phase. Safe
+  # for the closed-merged path: by the time we fire, the merge is on
+  # main and maintainer-approved. See #79 (extended scope).
+  pull_request_target:
     types: [closed]
   # Daily sweep at 06:00 UTC
   schedule:

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -25,7 +25,14 @@ name: Implementation Merged — Close Issue
 #         confirms.
 
 on:
-  pull_request:
+  # pull_request_target instead of pull_request so Copilot-coding-agent
+  # `copilot/*` PRs do not freeze the run in `action_required` during their
+  # draft phase. By the time `closed` + `merged==true` fires, the merge
+  # commit is already on main with maintainer approval, so running the
+  # handler from `merge_commit_sha` under maintainer-context permissions
+  # is the same trust as any post-merge main commit. See #79 (extended
+  # scope: closed-event family).
+  pull_request_target:
     types: [closed]
 
 permissions:

--- a/.github/workflows/spec-merged-build.yml
+++ b/.github/workflows/spec-merged-build.yml
@@ -1,7 +1,11 @@
 name: Spec Merged — Trigger Build
 
 on:
-  pull_request:
+  # pull_request_target so Copilot-coding-agent `copilot/*` spec PRs do
+  # not freeze in `action_required` during their draft phase. Safe for
+  # the closed-merged path: merge is already on main and maintainer-
+  # approved by the time we fire. See #79 (extended scope).
+  pull_request_target:
     types: [closed]
 
 permissions:


### PR DESCRIPTION
## Summary

Closes #79 with extended scope. Swaps `pull_request: types: [closed]` → `pull_request_target: types: [closed]` on three workflows so Copilot-coding-agent PRs (`copilot/*`) no longer freeze them in `action_required` during the draft phase.

## What lands

- `.github/workflows/impl-merged-close.yml`
- `.github/workflows/close-resolved-issues.yml`
- `.github/workflows/spec-merged-build.yml`

Each gets a comment block above the trigger explaining why the swap is safe for the closed-merged path (merge commit is already on main + maintainer-approved by the time the workflow fires).

## Why now

Observed on PR #576 (copilot/specification-issue-539) on 2026-05-08: all three workflows above sat in `action_required` after merge. Manual `gh run rerun` cleared them, but every future Copilot spec/impl PR hits the same wall without this fix. #79's earlier swap (board-sync.yml + copilot-undraft.yml) covered `[opened, labeled]` events; this PR closes the `[closed]` gap.

## Safety analysis

`pull_request_target` runs in maintainer-context with elevated permissions and full secrets. The standard concern (PR-author code running with elevated permissions, e.g., for fork PRs) does not apply for these workflows because:

- Trigger fires only on `closed` + (handler checks `merged==true` in its own `if:`).
- By that point, the merge commit is already on `main` with maintainer approval.
- The handler delegations (e.g., `actions/github-script@v8` calling into `scripts/workflows/impl-merged-close-handler.js`) read PR metadata via Octokit and do not execute PR-author code at runtime.
- Existing `actions/checkout@v4 ref: merge_commit_sha` (impl-merged-close.yml) keeps working — that SHA is part of main's history at trigger time, equivalent trust as any post-merge main commit.

Approve API was tried first and rejected with `HTTP 403: This run is not from a fork pull request` — Copilot agent branches are in-repo, not forks, so the fork-approval path does not apply. `gh run rerun` works but is manual cleanup, not a fix.

## Test plan

- [x] `actionlint` clean on all 3 changed workflows.
- [ ] Wait for next Copilot-coding-agent PR to merge with `closed`-event triggers; observe runs fire normally without `action_required`.
- [ ] Verify `impl-merged-close-handler.js` still receives correct `context.payload.pull_request` shape under `pull_request_target` (should be identical to `pull_request` per GH docs).