### PR TITLE
fix(bot): require Copilot APPROVED for autonomous merge (#595)

### DIFF
--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -1,5 +1,22 @@
 name: Bot PR Review and Merge
 
+# Autonomous review-and-merge workflow for bot-authored PRs.
+#
+# Policy (per issue #595, fixed 2026-05-09): admin-merge requires AT LEAST
+# ONE review with `state: APPROVED` AND ZERO reviews with
+# `state: CHANGES_REQUESTED`. `COMMENTED` and `DISMISSED` are informational
+# only and do NOT satisfy the gate. Effective state per reviewer = the
+# most-recent review submission (GitHub GraphQL `latestReviews`).
+#
+# Prior bug: the script's `poll_for_review` counted any review via
+# `length`. PRs #577 (reverted via #580), #589 (repaired via #596), and
+# #596 itself all merged with unresolved Copilot inline findings because
+# Copilot submits findings as `state: COMMENTED`. The new gate blocks
+# that pattern. See company/scripts/pr-review-merge_test.sh for the
+# regression guard. Belt-and-suspenders: `run_guardrails` re-checks the
+# verdict before invoking `gh pr merge`, so a race between poll exit and
+# state change cannot land an unapproved merge.
+
 on:
   pull_request:
     types: [opened, reopened]

--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -118,8 +118,115 @@ check_manual_only() {
 }
 
 # ---------------------------------------------------------------------------
-# poll_for_review — wait for Copilot review within a single poll window
-# Returns 0 if review found, 1 on timeout.
+# fetch_effective_review_states — compute most-recent review state per reviewer
+#
+# GitHub review state semantics (per docs.github.com/en/rest/pulls/reviews):
+#   APPROVED          — explicit approval; reviewer signs off
+#   CHANGES_REQUESTED — explicit blocking; merge must not proceed
+#   COMMENTED         — feedback only; NOT an approval signal
+#   DISMISSED         — review explicitly dismissed by maintainer
+#
+# The bug fixed here (issue #595): prior poll_for_review counted reviews via
+# `length`, so any submission of any state passed the gate. Copilot submits
+# inline findings as `state: COMMENTED`. The bot treated those as approvals
+# and admin-merged PRs with unresolved review findings (#577 reverted via
+# #580; #589 → #596 repair; #596 itself shipped 4 more unresolved findings).
+#
+# A reviewer's CURRENT effective state = the state of their most-recent
+# non-DISMISSED review submission. We compute it via GraphQL latestReviews
+# which returns exactly one review per reviewer (the most recent), keyed
+# by author.
+#
+# Outputs: zero or more lines of `<login>:<STATE>` to stdout. Empty output
+# = no reviews on the PR. Returns 0 on success, 1 on API failure.
+# ---------------------------------------------------------------------------
+fetch_effective_review_states() {
+  local pr="$1"
+  local owner repo
+  owner="${TARGET_REPO%%/*}"
+  repo="${TARGET_REPO##*/}"
+
+  if ! gh api graphql \
+    -F owner="$owner" \
+    -F repo="$repo" \
+    -F pr="$pr" \
+    -f query='
+      query($owner: String!, $repo: String!, $pr: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $pr) {
+            latestReviews(first: 100) {
+              nodes {
+                state
+                author { login }
+              }
+            }
+          }
+        }
+      }' \
+    --jq '.data.repository.pullRequest.latestReviews.nodes[] | "\(.author.login):\(.state)"' 2>/dev/null; then
+    echo "::error::Failed to fetch effective review states for PR #${pr}"
+    ERRORS=$((ERRORS + 1))
+    check_circuit_breaker
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# evaluate_review_states — decide whether the review-state gate passes
+#
+# Reads `<login>:<STATE>` lines on stdin. Echoes one of:
+#   PASS                       — at least one APPROVED, no CHANGES_REQUESTED
+#   BLOCKED:CHANGES_REQUESTED  — at least one reviewer is blocking
+#   PENDING:NONE               — no reviews yet
+#   PENDING:NO_APPROVED        — reviews present, but none APPROVED
+#
+# The PASS condition is conjunctive: APPROVED present AND zero
+# CHANGES_REQUESTED. COMMENTED and DISMISSED are informational — they neither
+# approve nor block. APPROVED from any reviewer in the approving-set counts.
+# Currently every reviewer counts; tighten to a specific allowlist
+# (e.g., copilot-pull-request-reviewer[bot]) only if a "wrong reviewer
+# approved" failure mode is observed in practice.
+# ---------------------------------------------------------------------------
+evaluate_review_states() {
+  local approved_count=0
+  local changes_requested_count=0
+  local total=0
+  local line state
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    total=$((total + 1))
+    state="${line##*:}"
+    case "$state" in
+      APPROVED) approved_count=$((approved_count + 1)) ;;
+      CHANGES_REQUESTED) changes_requested_count=$((changes_requested_count + 1)) ;;
+      *) ;;
+    esac
+  done
+
+  if [[ "$total" -eq 0 ]]; then
+    echo "PENDING:NONE"
+    return
+  fi
+  if [[ "$changes_requested_count" -gt 0 ]]; then
+    echo "BLOCKED:CHANGES_REQUESTED"
+    return
+  fi
+  if [[ "$approved_count" -gt 0 ]]; then
+    echo "PASS"
+    return
+  fi
+  echo "PENDING:NO_APPROVED"
+}
+
+# ---------------------------------------------------------------------------
+# poll_for_review — wait for an APPROVED review within a single poll window
+#
+# Per issue #595: the gate now requires at least one APPROVED reviewer AND
+# zero CHANGES_REQUESTED reviewers. COMMENTED submissions no longer satisfy
+# the gate. Returns 0 only when the state evaluation is PASS, returns 1 on
+# poll-window timeout. On BLOCKED, escalates immediately and returns 1
+# (no point polling further when a reviewer is actively blocking).
 # ---------------------------------------------------------------------------
 poll_for_review() {
   local pr="$1" window="$2"
@@ -127,17 +234,28 @@ poll_for_review() {
   local max_attempts="$POLL_MAX_ATTEMPTS"
 
   for attempt in $(seq 1 "$max_attempts"); do
-    local review_count
-    if ! review_count=$(gh api "repos/${TARGET_REPO}/pulls/${pr}/reviews" --jq 'length' 2>/dev/null); then
-      echo "::warning::Failed to fetch reviews for PR #${pr} (window ${window}, attempt ${attempt})"
-      ERRORS=$((ERRORS + 1))
-      check_circuit_breaker
+    local states verdict
+    if ! states=$(fetch_effective_review_states "$pr"); then
+      # error already logged + counted by fetch_effective_review_states
+      :
     else
-      if [[ "$review_count" -gt 0 ]]; then
-        echo "Review found for PR #${pr} after ${attempt} poll(s) (window ${window})"
-        log_audit "review_detected" "Review found in window ${window}, attempt ${attempt}"
-        return 0
-      fi
+      verdict=$(echo "$states" | evaluate_review_states)
+      case "$verdict" in
+        PASS)
+          echo "Review APPROVED for PR #${pr} after ${attempt} poll(s) (window ${window})"
+          log_audit "review_approved" "APPROVED state in window ${window}, attempt ${attempt}"
+          return 0
+          ;;
+        BLOCKED:*)
+          echo "::warning::Review BLOCKED for PR #${pr}: ${verdict}"
+          log_audit "review_blocked" "Verdict ${verdict} in window ${window}, attempt ${attempt}"
+          escalate "$pr" "Reviewer requested changes (state: CHANGES_REQUESTED) — manual resolution required"
+          return 1
+          ;;
+        PENDING:*)
+          # Keep polling; review may not be in yet, or only COMMENTED so far.
+          ;;
+      esac
     fi
 
     if [[ "$attempt" -lt "$max_attempts" ]]; then
@@ -145,7 +263,7 @@ poll_for_review() {
     fi
   done
 
-  echo "::warning::Review poll window ${window} expired for PR #${pr}"
+  echo "::warning::Review poll window ${window} expired for PR #${pr} (no APPROVED state)"
   return 1
 }
 
@@ -292,8 +410,24 @@ run_guardrails() {
     return 1
   fi
 
+  # 6. Review state belt-and-suspenders (issue #595)
+  # poll_for_review already enforces APPROVED-required, but the merge gate
+  # re-checks here so a race between poll exit and state change cannot land
+  # an unapproved merge. Cheap call (one GraphQL request) compared to the
+  # cost of shipping unverified code.
+  local guardrail_states guardrail_verdict
+  if ! guardrail_states=$(fetch_effective_review_states "$PR_NUMBER"); then
+    return 1
+  fi
+  guardrail_verdict=$(echo "$guardrail_states" | evaluate_review_states)
+  if [[ "$guardrail_verdict" != "PASS" ]]; then
+    escalate "$PR_NUMBER" "Review state guardrail failed (verdict: ${guardrail_verdict}): ${guardrail_states//$'\n'/, }"
+    check_circuit_breaker
+    return 1
+  fi
+
   # All guardrails passed
-  log_audit "guardrails_passed" "All guardrails passed"
+  log_audit "guardrails_passed" "All guardrails passed (review verdict: PASS)"
   return 0
 }
 
@@ -367,6 +501,32 @@ merge_pr() {
     echo "PR #${pr} was closed externally"
     log_audit "closed" "PR closed externally — skipping merge"
     return 0
+  fi
+
+  # Pre-merge audit comment (issue #595): name the approving reviewer + state
+  # explicitly so the audit trail is reconstructible from PR comments alone.
+  # Best-effort — failure to post the audit comment does not block the merge,
+  # but the audit log still records the verdict.
+  local audit_states audit_verdict audit_summary
+  if audit_states=$(fetch_effective_review_states "$pr" 2>/dev/null); then
+    audit_verdict=$(echo "$audit_states" | evaluate_review_states)
+    if [[ -z "$audit_states" ]]; then
+      audit_summary="(no reviews recorded)"
+    else
+      audit_summary=$(echo "$audit_states" | tr '\n' '; ' | sed 's/; $//')
+    fi
+    local audit_body
+    audit_body=$(jq -nc \
+      --arg verdict "$audit_verdict" \
+      --arg summary "$audit_summary" \
+      '"### Bot pre-merge audit\n\n- Verdict: " + $verdict + "\n- Effective review states: " + $summary + "\n\n_Recorded by `bot-pr-review-merge.yml` per issue #595._"')
+    audit_body="${audit_body:1:${#audit_body}-2}"
+    if ! gh pr comment "$pr" --repo "$TARGET_REPO" --body "$audit_body" >/dev/null 2>&1; then
+      echo "::warning::Failed to post pre-merge audit comment on PR #${pr}"
+    fi
+    log_audit "pre_merge_audit" "verdict=${audit_verdict} states=${audit_summary}"
+  else
+    echo "::warning::Pre-merge audit fetch failed for PR #${pr} — proceeding (guardrails already passed)"
   fi
 
   # Attempt merge (up to 2 tries: initial + 1 retry for conflict recovery)
@@ -557,4 +717,7 @@ main() {
   fi
 }
 
-main "$@"
+# Run main only when invoked directly, not when sourced (e.g., by tests).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/company/scripts/pr-review-merge_test.sh
+++ b/company/scripts/pr-review-merge_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tests for pr-review-merge.sh review-state policy (issue #595).
+#
+# Strategy: source the main script with required env vars set + a stub
+# `check_circuit_breaker` (so error counting in the helpers does not abort
+# tests), then exercise the pure helper `evaluate_review_states` against
+# canned input. `fetch_effective_review_states` wraps a single `gh api`
+# call and is not unit-tested here — the policy logic lives in
+# `evaluate_review_states`.
+#
+# Run: bash company/scripts/pr-review-merge_test.sh
+# Exits 0 on success, 1 on first assertion failure.
+
+set -euo pipefail
+
+# Required env vars for the script's fail-fast guards.
+export PR_NUMBER=999
+export TARGET_REPO="atvirokodosprendimai/wgmesh"
+export GH_TOKEN="dummy"
+export RUN_ID="test-$$"
+export AUDIT_LOG="/tmp/pr-review-merge_test-audit.jsonl"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/pr-review-merge.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS  $name"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL  $name"
+    echo "        got:  ${got}"
+    echo "        want: ${want}"
+  fi
+}
+
+# Scenario 1: single APPROVED review → PASS.
+out=$(printf 'copilot-pull-request-reviewer[bot]:APPROVED\n' | evaluate_review_states)
+assert_eq "$out" "PASS" "single APPROVED review yields PASS"
+
+# Scenario 2: single COMMENTED review → PENDING:NO_APPROVED.
+# This is the bug class that shipped #577, #589, #596 — the prior code
+# treated this as a green light. New policy must NOT pass.
+out=$(printf 'copilot-pull-request-reviewer[bot]:COMMENTED\n' | evaluate_review_states)
+assert_eq "$out" "PENDING:NO_APPROVED" "single COMMENTED review yields PENDING (regression guard for #577/#589/#596)"
+
+# Scenario 3: latestReviews already deduplicates per reviewer; the helper
+# only ever sees the most-recent state per login. Verify a bare APPROVED
+# yields PASS regardless of any earlier COMMENTED that might have existed.
+out=$(printf 'copilot-pull-request-reviewer[bot]:APPROVED\n' | evaluate_review_states)
+assert_eq "$out" "PASS" "most-recent APPROVED yields PASS (latestReviews dedup contract)"
+
+# Scenario 4: one APPROVED + one CHANGES_REQUESTED → BLOCKED.
+out=$(printf 'reviewer-a:APPROVED\nreviewer-b:CHANGES_REQUESTED\n' | evaluate_review_states)
+assert_eq "$out" "BLOCKED:CHANGES_REQUESTED" "any CHANGES_REQUESTED beats APPROVED"
+
+# Scenario 5: no reviews → PENDING:NONE.
+out=$(printf '' | evaluate_review_states)
+assert_eq "$out" "PENDING:NONE" "no reviews yields PENDING:NONE"
+
+# Scenario 6: only DISMISSED reviews → PENDING:NO_APPROVED.
+# Dismissed reviews are intentionally not blocking, but they also do not
+# count as approval.
+out=$(printf 'reviewer-a:DISMISSED\n' | evaluate_review_states)
+assert_eq "$out" "PENDING:NO_APPROVED" "DISMISSED-only yields PENDING:NO_APPROVED"
+
+# Scenario 7: APPROVED + COMMENTED from different reviewers → PASS.
+# COMMENTED is informational only; it neither approves nor blocks.
+out=$(printf 'reviewer-a:APPROVED\nreviewer-b:COMMENTED\n' | evaluate_review_states)
+assert_eq "$out" "PASS" "APPROVED + COMMENTED-from-different-reviewer yields PASS"
+
+# Scenario 8: APPROVED + DISMISSED → PASS.
+out=$(printf 'reviewer-a:APPROVED\nreviewer-b:DISMISSED\n' | evaluate_review_states)
+assert_eq "$out" "PASS" "APPROVED + DISMISSED yields PASS"
+
+# Scenario 9: APPROVED + CHANGES_REQUESTED + COMMENTED → BLOCKED wins.
+out=$(printf 'reviewer-a:APPROVED\nreviewer-b:CHANGES_REQUESTED\nreviewer-c:COMMENTED\n' | evaluate_review_states)
+assert_eq "$out" "BLOCKED:CHANGES_REQUESTED" "BLOCKED wins regardless of mix"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
Closes #595.

## Summary

Replaces the autonomous merge gate's review-detection logic with one that distinguishes `APPROVED` from `COMMENTED`. The bot previously counted any review submission as approval; this PR makes it require ≥1 `APPROVED` from the most-recent review per reviewer AND zero `CHANGES_REQUESTED` from anyone.

## Damage in last 48h that motivated this

Three concrete merges of unverified code, all caused by the same bug:

- **PR #577** (Goose Tier 5 NAT) — 13 unresolved Copilot findings, admin-merged, decoration-not-implementation tests shipped, reverted via [PR #580](https://github.com/atvirokodosprendimai/wgmesh/pull/580).
- **PR #589** (PIM foundation) — 5 unresolved findings, admin-merged, repaired via [PR #596](https://github.com/atvirokodosprendimai/wgmesh/pull/596).
- **PR #596** (PIM repair) — 4 unresolved findings, admin-merged 2026-05-09 ~15:33 UTC. No repair PR yet; the four bugs are live on main as of this PR's open.

## Mechanism

GitHub review state semantics (per `docs.github.com/en/rest/pulls/reviews`):

| State | Meaning |
|---|---|
| `APPROVED` | Explicit approval |
| `CHANGES_REQUESTED` | Explicit blocking |
| `COMMENTED` | **Feedback only, NOT an approval signal** |
| `DISMISSED` | Explicitly dismissed by maintainer |

The bot's `poll_for_review` (in `company/scripts/pr-review-merge.sh`) counted reviews via `gh api .../reviews --jq 'length'` — any submission of any state passed the gate. Copilot submits inline findings as `state: COMMENTED`, so the bot treated those as approvals.

## Changes

| Component | Change |
|---|---|
| `fetch_effective_review_states` (new) | GraphQL `latestReviews` returns the most-recent state per reviewer. Outputs `<login>:<STATE>` lines. |
| `evaluate_review_states` (new) | Pure helper. Computes `PASS` / `BLOCKED:CHANGES_REQUESTED` / `PENDING:NO_APPROVED` / `PENDING:NONE`. |
| `poll_for_review` (replaced) | Now waits for verdict=`PASS`. Escalates immediately on `BLOCKED`. Returns 1 on poll-window timeout. |
| `run_guardrails` Step 6 (new) | Re-checks the verdict before invoking `gh pr merge`. Belt-and-suspenders against polling-vs-state-change races. |
| `merge_pr` audit comment (new) | Posts the verdict + per-reviewer effective state on the PR before merging. Audit trail is reconstructible from PR comments alone. |
| `company/scripts/pr-review-merge_test.sh` (new) | 9 scenarios — APPROVED / COMMENTED / DISMISSED / CHANGES_REQUESTED / mixes / empty / explicit regression guard for the #577 / #589 / #596 bug pattern. |
| `.github/workflows/bot-pr-review-merge.yml` | Top-of-file policy comment block. No structural workflow change. |

## Test plan

- [x] `bash company/scripts/pr-review-merge_test.sh` — 9 passed, 0 failed.
- [x] `bash -n company/scripts/pr-review-merge.sh` — clean syntax.
- [x] `actionlint .github/workflows/bot-pr-review-merge.yml` — clean.
- [x] Existing functionality (`escalate`, `reassign_agent`, `merge_pr` retry + post-check, spec-validation gate) untouched.
- [ ] **Manual approval required.** This PR itself will be reviewed under the OLD policy (which ships unverified) until it merges and the new code is on main. Do NOT let the autonomous bot handle this PR. A maintainer must `APPROVE` explicitly.

## Out of scope

- Reverting #596 — addressed via a separate follow-up PR.
- Auditing other auto-merge surfaces (`auto-merge.yml`) — separate audit.
- Adding a max-unresolved-comments threshold — orthogonal; can be a follow-up.

## Acceptance criteria from #595

- [x] `bot-pr-review-merge.yml`'s approval-detection requires `state: APPROVED` AND zero `state: CHANGES_REQUESTED`.
- [x] Bot pre-merge comment names the verdict + per-reviewer effective state.
- [ ] Optional: max-unresolved-comments threshold — not implemented; can be a follow-up.
- [x] Verification: regression guards in `_test.sh` simulate the #577 / #589 / #596 conditions and confirm the new gate blocks them.