### PR TITLE
fix(testlab): bound wait_for probe with bash watchdog (unblocks #571 diagnosis)

### DIFF
--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -152,14 +152,58 @@ run_on_all() {
 
 # Wait until a condition command succeeds, with timeout.
 # Usage: wait_for <description> <timeout_sec> <command...>
+#
+# Each probe attempt is itself bounded by WAIT_FOR_PROBE_TIMEOUT_SEC
+# (default 15s) via a pure-bash watchdog. Without this bound, a probe
+# predicate that hangs — most commonly an SSH call to a node whose wgmesh
+# has deadlocked or whose link is impaired — will block this loop forever;
+# the outer timeout check below only fires between probe attempts, not
+# during one. Hetzner integration run 25609234757 (2026-05-09) hit
+# exactly this: Tier 2 + Tier 4 each blocked for ~2 hours inside a single
+# probe call until the GitHub Actions job-level timeout-minutes: 120
+# force-cancelled the run. The per-probe watchdog converts an indefinite
+# hang into a probe failure that the outer loop can register and either
+# retry or time out from.
+#
+# Why a bash watchdog instead of `timeout(1)`: predicates here are shell
+# functions like `_t1_check`, `_t5_check` defined in test-cloud.sh.
+# `timeout` is an external program; once it execs into its child it
+# cannot see shell functions, so `timeout 15 _t1_check ...` would fail
+# with "command not found". The subshell + background-watchdog pattern
+# preserves function visibility while bounding the probe.
+#
+# See docs/solutions/test-failures/tier3-t14-80pct-loss-ssh-hang.md for
+# the same SSH-on-impaired-target pattern.
 wait_for() {
     local desc="$1" timeout="$2"; shift 2
+    local probe_timeout="${WAIT_FOR_PROBE_TIMEOUT_SEC:-15}"
     local start end
     start=$(date +%s)
     end=$((start + timeout))
 
     while true; do
-        if "$@" 2>/dev/null; then
+        # Run the predicate in a subshell so functions are visible, and
+        # poll its PID with kill -0 against a per-probe deadline. On
+        # deadline, SIGKILL the subshell and treat the probe as failed.
+        ( "$@" 2>/dev/null ) &
+        local probe_pid=$!
+        local probe_deadline=$(( $(date +%s) + probe_timeout ))
+        local rc=124  # convention: 124 = bash watchdog killed
+        while [ "$(date +%s)" -lt "$probe_deadline" ]; do
+            if ! kill -0 "$probe_pid" 2>/dev/null; then
+                wait "$probe_pid" 2>/dev/null
+                rc=$?
+                break
+            fi
+            sleep 1
+        done
+        if kill -0 "$probe_pid" 2>/dev/null; then
+            kill -KILL "$probe_pid" 2>/dev/null
+            wait "$probe_pid" 2>/dev/null
+            rc=124
+        fi
+
+        if [ "$rc" -eq 0 ]; then
             local elapsed=$(( $(date +%s) - start ))
             log_info "$desc — succeeded after ${elapsed}s"
             return 0


### PR DESCRIPTION
## Summary

Bounds each individual probe attempt in `testlab/cloud/lib.sh:wait_for` with a pure-bash watchdog (default 15s per probe via `WAIT_FOR_PROBE_TIMEOUT_SEC`). Without this bound, a hanging predicate — most often an SSH call into a node whose wgmesh has deadlocked or whose link is impaired — blocks `wait_for` indefinitely despite its declared outer timeout.

This is the root cause of why Hetzner integration run [25609234757](https://github.com/atvirokodosprendimai/wgmesh/actions/runs/25609234757) (manual probe against current main, 2026-05-09 18:58 UTC) silently hung for ~2 hours on both Tier 2 and Tier 4 instead of failing within the per-test 90s budget.

## Failure observed

| Tier | Test | Last visible log | Hung until job timeout |
|---|---|---|---|
| Tier 2 | T5 Late peer join | `19:01:29 Stopped wgmesh on node-d` | 1h58m → cancel at 20:59 |
| Tier 4 | T20 Partial partition | `19:02:04 Stopped wgmesh on node-d` | 1h57m → cancel at 20:59 |

Both tests' next call after stop_mesh is `wait_for "initial 3-node mesh" 90 _t1_check ...` — outer timeout 90s, but the run blocked indefinitely.

## Root cause

Pre-fix `wait_for`:

```bash
while true; do
    if "$@" 2>/dev/null; then ...; return 0; fi
    if [ "$(date +%s)" -ge "$end" ]; then ...; return 1; fi
    sleep 2
done
```

The `[ ... -ge "$end" ]` check only fires *between* probe attempts. If `"$@"` itself blocks — e.g., an SSH call into a wgmesh node whose daemon has deadlocked, or `mesh_ping` whose underlying SSH never returns — the loop is wedged inside the `if` line and never reaches the timeout check. Same SSH-on-impaired-target pattern documented in [`docs/solutions/test-failures/tier3-t14-80pct-loss-ssh-hang.md`](docs/solutions/test-failures/tier3-t14-80pct-loss-ssh-hang.md). That earlier fix bounded chaos-clear via atomic SSH; this one bounds the probe.

## Fix shape

Pure-bash watchdog: run probe in subshell, poll its PID with `kill -0` against per-probe deadline, SIGKILL on expiry.

Why not `timeout(1)`: predicates here are shell functions (`_t1_check`, `_t5_check`, `_t6_check`) defined in `test-cloud.sh`. `timeout` is an external program; its child cannot see shell functions, so `timeout 15 _t1_check ...` would fail with command-not-found. The subshell-fork pattern preserves function visibility while bounding the probe.

## Test plan

- [x] Smoke test (`/tmp/wait-for-test.sh`): 4 scenarios all pass.
  - Instant success → 0s, rc=0.
  - Always-fail predicate, outer 4s → rc=1 at 4s.
  - **Hanging predicate (`sleep 999`), probe_timeout 2s, outer 5s → rc=1 at 6s.** Pre-fix would block 999s.
  - Function predicate that succeeds on 2nd attempt → rc=0 at 2s. Confirms subshell sees functions.
- [x] `bash -n testlab/cloud/lib.sh` clean.
- [ ] Re-run `gh workflow run hetzner-integration.yml --ref main -f tiers=\"2,4\" -f vm_count=5` after merge. Expected behavior change: tests FAIL within their declared budgets (~90-120s each) instead of hanging. Failures will then surface the underlying mesh-convergence bug — root cause unaddressed by this PR but no longer obscured.

## Why now

Closes the diagnostic-shaped half of issue [#571](https://github.com/atvirokodosprendimai/wgmesh/issues/571) (Tier 5 NAT release blocker). Founder's exact phrase from the session: *"i just want this nat feature that blocks release"*. Before this fix, manual probes against current main hang silently; founder cannot tell the difference between "still running" and "broken". Post-fix, the same probe will fail loudly within minutes and surface the actual mesh-convergence bug for diagnosis.

The actual mesh-convergence bug (whatever it turns out to be — daemon deadlock, DHT bootstrap stuck, hole-punching infinite-retry, etc.) is **out of scope** for this PR. This fix unblocks the diagnostic loop. Ship this first, then iterate on the real bug.

## Out of scope

- Bounding `stop_mesh` / `start_mesh_node` themselves — those run a single SSH command each, bounded by `ConnectTimeout=10 + ServerAliveInterval`. Not currently observed to hang.
- Reducing default `WAIT_FOR_PROBE_TIMEOUT_SEC` below 15s. 15s gives slow introducer rendezvous room while still bounding worst case.
- Tier 5 NAT topology implementation — separate track via [PR #575](https://github.com/atvirokodosprendimai/wgmesh/pull/575).
- Diagnosing the underlying mesh-convergence hang — separate follow-up after this lands and the next probe surfaces a real failure.

## Note

This PR will be reviewed under the new bot policy from PR #597 (merged 2026-05-09 19:41) — bot now requires `state: APPROVED`, not `COMMENTED`. Should not auto-merge on Copilot inline findings alone.