### PR TITLE
feat(testlab): opt-in coroot-node-agent on test VMs for kernel-level diagnosis

### DIFF
--- a/testlab/cloud/provision.sh
+++ b/testlab/cloud/provision.sh
@@ -269,22 +269,40 @@ _setup_single_vm() {
     # Optional: install coroot-node-agent for kernel-level (eBPF) observability.
     # Opt-in via WGMESH_COROOT=1 to avoid paying the install cost on every run.
     # Collector endpoint defaults to https://table.beerpub.dev (per memory:
-    # Coroot observability setup); override via WGMESH_COROOT_COLLECTOR. Agent
-    # needs root + privileged + debugfs to attach BPF programs. Useful when
-    # diagnosing kernel-level hangs (e.g., wgmesh shutdown blocking on
+    # Coroot observability setup); override via WGMESH_COROOT_COLLECTOR.
+    #
+    # Source defaults to nycterent's PR coroot/coroot-node-agent#301 branch
+    # `fix-l7-memory-oom` (replaces stateful Prometheus objects with
+    # lightweight storage to prevent OOM — fixes the agent OOMing at 9GB on
+    # busy nodes, which would otherwise OOM-kill mid-test and obscure the
+    # very hang we're trying to observe). Override the source with
+    # WGMESH_COROOT_REPO and WGMESH_COROOT_REF for upstream comparison.
+    #
+    # Built from source on each VM so the binary matches whatever revision
+    # WGMESH_COROOT_REF points to. ~1 minute extra setup; only runs when
+    # WGMESH_COROOT=1.
+    #
+    # Agent needs root + privileged + debugfs to attach BPF programs. Useful
+    # when diagnosing kernel-level hangs (e.g., wgmesh shutdown blocking on
     # netlink/RTNL — the symptom from Hetzner run 25609234757).
     if [ "${WGMESH_COROOT:-0}" = "1" ]; then
         local coroot_endpoint="${WGMESH_COROOT_COLLECTOR:-https://table.beerpub.dev}"
-        local coroot_arch="arm64"
+        local coroot_repo="${WGMESH_COROOT_REPO:-https://github.com/coroot/coroot-node-agent.git}"
+        local coroot_ref="${WGMESH_COROOT_REF:-fix-l7-memory-oom}"
         run_on "$node" "
             export DEBIAN_FRONTEND=noninteractive
+            apt-get install -y -qq golang-go git build-essential >/dev/null 2>&1
             mkdir -p /opt/coroot
-            curl -fsSL --retry 3 -o /opt/coroot/coroot-node-agent \
-                https://github.com/coroot/coroot-node-agent/releases/latest/download/coroot-node-agent-linux-${coroot_arch} 2>/dev/null
+            cd /tmp
+            rm -rf coroot-node-agent-src
+            git clone --depth 1 --branch '${coroot_ref}' '${coroot_repo}' coroot-node-agent-src
+            cd coroot-node-agent-src
+            CGO_ENABLED=1 go build -trimpath -ldflags='-s -w' -o /opt/coroot/coroot-node-agent .
+            cd / && rm -rf /tmp/coroot-node-agent-src
             chmod +x /opt/coroot/coroot-node-agent
             cat > /etc/systemd/system/coroot-node-agent.service << 'UNIT'
 [Unit]
-Description=Coroot eBPF node agent (test VM observability)
+Description=Coroot eBPF node agent (test VM observability — PR #301 fix-l7-memory-oom)
 After=network-online.target
 Wants=network-online.target
 
@@ -293,6 +311,8 @@ Type=simple
 ExecStart=/opt/coroot/coroot-node-agent --collector-endpoint=${coroot_endpoint} --cgroupfs-root=/sys/fs/cgroup
 Restart=on-failure
 LimitNOFILE=65535
+MemoryHigh=2G
+MemoryMax=4G
 
 [Install]
 WantedBy=multi-user.target
@@ -300,7 +320,7 @@ UNIT
             systemctl daemon-reload
             systemctl enable --now coroot-node-agent
         "
-        log_info "VM $node coroot-node-agent started (collector=${coroot_endpoint})"
+        log_info "VM $node coroot-node-agent built + started (ref=${coroot_ref}, collector=${coroot_endpoint})"
     fi
 
     # Copy binary

--- a/testlab/cloud/provision.sh
+++ b/testlab/cloud/provision.sh
@@ -266,6 +266,43 @@ _setup_single_vm() {
         mkdir -p /usr/local/bin /var/lib/wgmesh
     "
 
+    # Optional: install coroot-node-agent for kernel-level (eBPF) observability.
+    # Opt-in via WGMESH_COROOT=1 to avoid paying the install cost on every run.
+    # Collector endpoint defaults to https://table.beerpub.dev (per memory:
+    # Coroot observability setup); override via WGMESH_COROOT_COLLECTOR. Agent
+    # needs root + privileged + debugfs to attach BPF programs. Useful when
+    # diagnosing kernel-level hangs (e.g., wgmesh shutdown blocking on
+    # netlink/RTNL — the symptom from Hetzner run 25609234757).
+    if [ "${WGMESH_COROOT:-0}" = "1" ]; then
+        local coroot_endpoint="${WGMESH_COROOT_COLLECTOR:-https://table.beerpub.dev}"
+        local coroot_arch="arm64"
+        run_on "$node" "
+            export DEBIAN_FRONTEND=noninteractive
+            mkdir -p /opt/coroot
+            curl -fsSL --retry 3 -o /opt/coroot/coroot-node-agent \
+                https://github.com/coroot/coroot-node-agent/releases/latest/download/coroot-node-agent-linux-${coroot_arch} 2>/dev/null
+            chmod +x /opt/coroot/coroot-node-agent
+            cat > /etc/systemd/system/coroot-node-agent.service << 'UNIT'
+[Unit]
+Description=Coroot eBPF node agent (test VM observability)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/coroot/coroot-node-agent --collector-endpoint=${coroot_endpoint} --cgroupfs-root=/sys/fs/cgroup
+Restart=on-failure
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+            systemctl daemon-reload
+            systemctl enable --now coroot-node-agent
+        "
+        log_info "VM $node coroot-node-agent started (collector=${coroot_endpoint})"
+    fi
+
     # Copy binary
     copy_to "$node" "$BINARY_PATH" "/usr/local/bin/wgmesh"
     run_on "$node" "chmod +x /usr/local/bin/wgmesh"


### PR DESCRIPTION
## Summary

Adds eBPF-level observability to Hetzner test VMs via Coroot. Opt-in via `WGMESH_COROOT=1` to avoid install cost on every CI run. Default collector `https://table.beerpub.dev` (per existing Coroot setup).

## Why

Hetzner integration run [25609234757](https://github.com/atvirokodosprendimai/wgmesh/actions/runs/25609234757) hung silently for ~2h on Tier 2 + Tier 4. Pure Go-source audit (this session) confirmed all daemon-tracked goroutines + Stop() calls are ctx-clean — **the hang is below the Go layer**. Suspects:

- `anacrolix/dht.server.Close()` blocking
- `wireguard-go` TUN cleanup post-SIGKILL leaving kernel state corrupted
- Kernel netlink RTNL contention from orphan WG interface

None visible to PostHog-style app-level instrumentation. eBPF sees:

| Capability | What it shows |
|---|---|
| Process states | D = uninterruptible kernel sleep (the smoking gun for netlink hangs) |
| Syscall tracing | Which call is blocked + duration |
| Kernel stacks | Which mutex / lock is held |
| Network flows | SSH keepalive flow while command hangs (proves it's kernel, not network) |
| File I/O | Whether wgmesh's TUN fd closed cleanly |

That's the right tool for this bug class.

## What lands

`testlab/cloud/provision.sh::_setup_single_vm` — conditional install between apt deps and wgmesh binary copy:

- Download `coroot-node-agent-linux-arm64` static binary.
- Systemd unit at `/etc/systemd/system/coroot-node-agent.service`.
- Enable + start before wgmesh setup, so agent is observing across the full test lifecycle.

Activated only when `WGMESH_COROOT=1` is set on the test step env. Default CI runs unchanged.

## Test plan

- [x] `bash -n testlab/cloud/provision.sh` clean.
- [ ] Manual `workflow_dispatch` with `WGMESH_COROOT=1` env override; verify agent reports to `table.beerpub.dev`.
- [ ] Reproduce shutdown hang; read Coroot UI for blocked syscall + kernel stack.

## Out of scope

- Adding `WGMESH_COROOT` input to `hetzner-integration.yml` workflow YAML — separate follow-up if diagnostic flow becomes routine.
- Fixing the actual shutdown hang. This PR ships **diagnostic infrastructure**; the fix lands separately once Coroot localizes the hang.
- Replacing PostHog with Coroot for product analytics — different problems, keep both.

## Note

PR reviewed under new bot policy from #597 — requires `state: APPROVED`, not just `COMMENTED`. Manual maintainer approval required to land.

## Update — switch source to PR coroot/coroot-node-agent#301

Per founder direction, the agent is now built from source on each VM defaulting to the PR #301 branch `fix-l7-memory-oom` (authored by nycterent), which replaces stateful Prometheus objects with lightweight storage to prevent OOM (upstream issue #242). Without that fix the agent OOM-kills itself at 9GB on busy nodes — exactly the wrong outcome when diagnosing a kernel-level hang in another process.

Build cost ~1 min per VM, only when `WGMESH_COROOT=1`. Override knobs: `WGMESH_COROOT_REPO` + `WGMESH_COROOT_REF` (default `fix-l7-memory-oom`). Set `WGMESH_COROOT_REF=master` to compare upstream behavior side-by-side.

Belt-and-suspenders: systemd unit caps memory at `MemoryHigh=2G` / `MemoryMax=4G`. Cgroup OOM-kills the agent specifically if the fix doesn't hold, rather than letting it starve wgmesh.

Field-tests PR #301 against real Hetzner workload while diagnosing the wgmesh shutdown hang — two birds.
