### PR TITLE
chore(workflow): add coroot input to hetzner-integration dispatch

### DIFF
--- a/.github/workflows/hetzner-integration.yml
+++ b/.github/workflows/hetzner-integration.yml
@@ -14,6 +14,11 @@ on:
         description: 'Number of VMs per tier (1 introducer + N-1 nodes)'
         required: false
         default: '5'
+      coroot:
+        description: 'Install coroot-node-agent on each test VM (PR #301 fix-l7-memory-oom build) for kernel-level diagnosis'
+        required: false
+        default: 'false'
+        type: boolean
 
 # Only one integration test run at a time (shared Hetzner infra)
 concurrency:
@@ -136,6 +141,7 @@ jobs:
           WGMESH_RUN_ID: "${{ github.run_id }}-t${{ matrix.tier }}"
           VM_PREFIX: "wgmesh-t${{ matrix.tier }}"
           WGMESH_PPROF: "1"
+          WGMESH_COROOT: ${{ inputs.coroot && '1' || '0' }}
 
       - name: Generate test report
         if: always()


### PR DESCRIPTION
Exposes `WGMESH_COROOT=1` (from PR #601) as a workflow_dispatch input. Default false. Manual probes set `-f coroot=true` to install the patched coroot-node-agent (PR #301 `fix-l7-memory-oom`) on each test VM for kernel-level diagnosis.

No behavior change on tag-push or default dispatch runs. Diff: 6 lines.

Closes the gap between PR #601 (install machinery) and `gh workflow run` invocation (couldn't trigger it before).