### PR TITLE
fix(testlab): add CGO build deps for coroot-node-agent (sd-journal.h)

### DIFF
--- a/testlab/cloud/provision.sh
+++ b/testlab/cloud/provision.sh
@@ -306,7 +306,7 @@ _setup_single_vm() {
         run_on "$node" "
             set -euo pipefail
             export DEBIAN_FRONTEND=noninteractive
-            apt-get install -y -qq golang-go git build-essential >/dev/null 2>&1
+            apt-get install -y -qq golang-go git build-essential libsystemd-dev libelf-dev pkg-config clang llvm linux-headers-generic >/dev/null 2>&1
             mkdir -p /opt/coroot
             cd /tmp
             rm -rf coroot-node-agent-src


### PR DESCRIPTION
Run 25630712189 hit `fatal error: systemd/sd-journal.h: No such file or directory` building coroot-node-agent. Adds libsystemd-dev + libelf-dev + pkg-config + clang + llvm + linux-headers-generic to apt install. PR #607's set -e + active-state verify made this surface as a fast fail instead of silent-success-with-no-data.