### PR TITLE
fix(testlab): pass --api-key to coroot-node-agent (the actual missing piece)

### DIFF
--- a/.compound-engineering/config.local.yaml
+++ b/.compound-engineering/config.local.yaml
@@ -1,0 +1,15 @@
+# --- Product pulse ---
+
+pulse_product_name: "wgmesh"
+pulse_lookback_default: 7d
+pulse_value_event: "synthetic_probe_handshake_completed"
+pulse_completion_events: "polar_subscription_created,polar_subscription_cancelled,github_star_added"
+pulse_quality_scoring: false
+pulse_analytics_source: chimney
+pulse_tracing_source: coroot
+pulse_payments_source: polar
+pulse_db_enabled: false
+pulse_metric_sources: "paying_customers=polar,cost_coverage_ratio=polar,weekly_active_meshes=chimney,time_to_mesh_p50=synthetic_probe,unsolicited_positive_feedback_rate=github"
+pulse_pending_metrics: "primary_engagement_event,time_to_mesh_p50,synthetic_probe_handshake_completed"
+pulse_excluded_metrics: ""
+pulse_schedule: daily

--- a/.github/workflows/hetzner-integration.yml
+++ b/.github/workflows/hetzner-integration.yml
@@ -142,6 +142,7 @@ jobs:
           VM_PREFIX: "wgmesh-t${{ matrix.tier }}"
           WGMESH_PPROF: "1"
           WGMESH_COROOT: ${{ inputs.coroot && '1' || '0' }}
+          COROOT_API_TOKEN: ${{ secrets.COROOT_API_TOKEN }}
 
       - name: Generate test report
         if: always()

--- a/docs/plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md
+++ b/docs/plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md
@@ -1,0 +1,430 @@
+---
+title: "feat: instrument 16 wgmesh GitHub Actions workflows with MentisDB thought-append"
+type: feat
+status: active
+date: 2026-04-27
+---
+
+# feat: instrument 16 wgmesh GitHub Actions workflows with MentisDB thought-append
+
+## Overview
+
+Phase 1 of the multi-repo MentisDB CI rollout. Wire 16 lifecycle workflows in `atvirokodosprendimai/wgmesh` to append structured thoughts to MentisDB at `mem.beerpub.dev`, mirroring the instrumentation just shipped in the sister repo `ai-pipeline-template` (PR #610 + heal #611). Three workflows already integrate (`agent-metrics-report.yml` weekly Summary, `release.yml` TaskComplete/Mistake on tag publish, `goose-build.yml` ActionTaken/Mistake on each build). The remaining 16 lifecycle workflows run silently — there is no agent-memory record of PR triage, spec validation, build dispatch, merge closure, infrastructure sync, or pages deployment.
+
+After this work, every meaningful CI event in wgmesh writes a typed thought into the `wgmesh` chain, restoring continuity for downstream agents that read MentisDB to reason about the product's pipeline state.
+
+---
+
+## Problem Frame
+
+wgmesh is the primary product repo per `ai-pipeline-template/.github/workflows/observation-loop.yml` (it is the one repo that gets full GitHub-signal collection + Product Codebase Summary in the daily strategic loop). Yet 16 of its 20 lifecycle workflows produce no MentisDB record beyond `gh run` logs that age out and lack semantic structure.
+
+Memory note `~/.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/reference_mentisdb_ci_integration_pattern.md` already defines the canonical step shape, thought-type table, fatality decision rules, and chain naming convention. This plan is a mechanical rollout of that pattern across the remaining wgmesh workflows; no architectural decisions are open. The sister repo's PR #610 ships exactly the same pattern across an equivalent set of workflows (10 there → 16 here), so the implementer has a verified precedent to mirror.
+
+Skip `sync-labels.yml` per pattern-doc convention (mirrors the ai-pipeline-template skip). Label-sync events are mechanical and high-frequency — they would flood the chain with noise.
+
+---
+
+## Requirements Trace
+
+- R1. Every lifecycle workflow in scope appends a thought to MentisDB on terminal job state (`success`, `failure`, `cancelled`), via `if: always()` so the append fires regardless of preceding step outcomes.
+- R2. All appends use `chain_key: "wgmesh"` to keep this repo's CI activity in one queryable chain (per pattern doc — one chain per repo).
+- R3. Append failures are non-fatal across all 16 workflows — `|| echo "::warning::mentisdb append failed (non-fatal)"`. Workflow primary outcome (build pass/fail, merge success, etc.) is unaffected by MentisDB hiccups.
+- R4. `thought_type`, `importance`, `tags`, and `content` are chosen per the pattern doc table for each workflow's event class. Specifically: `Correction` is reserved for "successful auto-fix from review with refs/relations to a Mistake thought" — do **not** use it for plain spec-validation success (use `ActionTaken` instead, per the lesson learned in ai-pipeline-template PR #610 review).
+- R5. No new secrets are introduced. Reuse existing org-level `MENTISDB_URL` / `MENTISDB_USER` / `MENTISDB_PASSWORD` — already provisioned for wgmesh per the org secrets inventory (visibility: selected → ai-pipeline-template + wgmesh).
+- R6. Existing wired workflows (`agent-metrics-report.yml`, `release.yml`, `goose-build.yml`) are not modified.
+- R7. `sync-labels.yml` is not instrumented (low-signal noise per pattern doc convention).
+- R8. Post-merge verification: at least one instrumented workflow per cluster fires (via natural trigger or `gh workflow run`), and the resulting thought lands in MentisDB chain `wgmesh` with the run_url matching the dispatched run.
+
+---
+
+## Scope Boundaries
+
+- Not modifying the three already-wired workflows (`agent-metrics-report`, `release`, `goose-build`).
+- Not instrumenting `sync-labels.yml` (low signal, high frequency).
+- Not changing the existing pattern (chain naming, thought_type table, step shape) — this plan consumes it.
+- Not adding new MentisDB secrets, rotating existing ones, or changing org secret visibility.
+- Not extracting a reusable composite action — pattern doc + ai-pipeline-template precedent both keep inline. Composite extraction is a separate concern, deferred to its own future plan once the rollout count and shape stabilizes.
+- Not instrumenting any additional secondary repo (lighthouse, chimney, coroot-cicd, etc.) — those are separate phases requiring secret-visibility widening first.
+
+### Deferred to Follow-Up Work
+
+- Composite-action extraction (`.github/actions/mentis-thought/`) — defer until 13+ workflows in any single repo OR a breaking MentisDB API change forces a sweep. Coordinate with sister repos when undertaken.
+- Phase 2 secondary-repo onboarding (coroot-cicd, chimney, tvcentras) — separate plan, requires `gh secret set ... --visibility selected --repos` widening first.
+- `sync-labels.yml` instrumentation — revisit if labels-sync events are ever judged worth memorializing (default: not).
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/agent-metrics-report.yml` — wgmesh-side reference impl (one of 3 already wired). Mirror its env-block + jq + curl shape.
+- `.github/workflows/release.yml` — release-event reference (TaskComplete on success, Mistake on failure, fatal append for tag publish).
+- `.github/workflows/goose-build.yml` — high-frequency reference (ActionTaken on success, non-fatal append).
+- Sister-repo plan: `ai-pipeline-template/docs/plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md` — same shape for 10 workflows, structurally identical to this plan's 16.
+- Sister-repo PR #610 commit `a612392` — squash-merged 10-workflow instrumentation. Diff is the canonical "what good looks like" for this work.
+- Sister-repo heal commit `190844e` (PR #611) — unrelated terraform fix; not relevant to this plan but documents a Hetzner gotcha worth knowing for the workflows that touch hetzner-integration.
+
+### Institutional Learnings
+
+- Pattern doc (authoritative): `~/.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/reference_mentisdb_ci_integration_pattern.md` — step shape, thought-type table, fatality rules, chain naming convention, onboarding checklist.
+- `ai-pipeline-template/docs/solutions/integration-issues/github-workflow-placeholder-validation-failures.md` — `secrets` context is **not** allowed in `if:` expressions; always use `env:` block. This plan correctly uses `env:` only.
+- `ai-pipeline-template/docs/solutions/integration-issues/github-app-reviews-dont-trigger-workflows.md` — App-actor reviews via GITHUB_TOKEN do not fire `pull_request_review` workflows. Affects `approve-build.yml` here (same caveat as ai-pipeline-template's). Surface as advisory, not as a defect introduced by this plan.
+- `ai-pipeline-template/docs/solutions/runtime-errors/coroot-disk-full-outage-recovery.md` — `if: always()` is the only reliable execution guarantee when prior steps fail. This plan uses it on every step.
+- `ai-pipeline-template/docs/solutions/integration-issues/autonomous-review-merge-bootstrap.md` — log-cleanliness patterns for curl/gh in workflows. Mirror the silent-but-show-error curl pattern.
+- Memory note `feedback_mentisdb_no_rest_auth.md` — REST has zero built-in auth; nginx Basic Auth is the gate. Step shape must include `-u "$MENTISDB_USER:$MENTISDB_PASSWORD"`.
+
+### External References
+
+- None required — pattern is fully internal and battle-tested in 3 wgmesh workflows + 11 ai-pipeline-template workflows + ai-pipeline-template's heartbeat/observation-loop production runs.
+
+---
+
+## Key Technical Decisions
+
+- **Per-workflow inline step over reusable composite action.** Same rationale as the sister-repo plan: pattern doc + multi-repo precedent both use inline steps. Inline keeps per-workflow content/tag choices visible at the point of use. Composite extraction deferred (see Scope Boundaries).
+- **Non-fatal append for all 16 workflows.** None are release events or low-frequency metrics rollups (those are already wired and use fatal append). This batch is operational lifecycle events where the build/merge outcome is the primary signal and MentisDB observability is supplementary. Append: `|| echo "::warning::mentisdb append failed (non-fatal)"`.
+- **`if: always()` placement.** Append step must run regardless of preceding step outcomes so failure thoughts get recorded. Place as the last step in each job. Explicit exception: none in this batch (no equivalent of ai-pipeline-template's `health-check.yml` failure-only gate).
+- **Single chain `wgmesh` for all 16 workflows.** Pattern doc: one chain per repo. Workflow identity is preserved via `agent_id` (workflow filename without extension) and tags.
+- **`agent_id` / `agent_name` convention.** Use the workflow's filename minus `.yml` extension (e.g., `bot-pr-review-merge`, `dns-update`, `pages`). Matches existing `agent-metrics-report` / `release` / `goose-build` convention.
+- **Tag schema:** `["wgmesh", "<event-type>", $outcome]`. `<event-type>` is the action-flavored noun the workflow performs, NOT necessarily the agent_id. Per ai-pipeline-template review: agent_id ≠ tag is intentional design (tag describes the event semantic; agent_id describes the workflow identity).
+- **Importance values from pattern doc table.** Do not invent new importance scores. ActionTaken=0.5, TaskComplete=0.7, Mistake=0.7-0.8, Correction=0.6 (rare), Insight=0.4.
+- **`Correction` is reserved.** Per pattern doc and ai-pipeline-template review: only use TYPE=Correction when the workflow literally fixes a prior Mistake thought (with refs/relations to it). For all 16 workflows in this plan, success cases use ActionTaken (or TaskComplete for terminal merges/builds). No workflow in this batch uses Correction.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Build a reusable composite action?** No. Same answer as ai-pipeline-template plan — pattern doc + multi-repo precedent both use inline. Composite extraction deferred to a separate plan.
+- **Q: Should `auto-merge.yml` (general PR auto-merge) and `bot-pr-review-merge.yml` both append?** Yes. They handle different actor classes (`auto-merge` is general; `bot-pr-review-merge` is bot-authored). Both events warrant chain entries with distinct tags (`auto-merge` vs `pr-review-merge`).
+- **Q: Should `goose-review.yml` use TYPE=Correction on success?** No. Use ActionTaken. Goose review is a quality gate that produces a review verdict, not an auto-fix. Correction is only for workflows that literally fix a prior Mistake.
+- **Q: Should `spec-auto-approve.yml` use Correction?** No. Use ActionTaken on success. This is the lesson directly carried from ai-pipeline-template PR #610 review (where `spec-validation.yml` was initially set to Correction and had to be heal-fixed to ActionTaken). Pre-empt the same mistake here.
+- **Q: Cross-repo chain references?** No. Each repo's chain is self-contained. Cross-repo correlation happens at query time (`tags_any=["release"]` across multiple chains), not via chain links.
+
+### Deferred to Implementation
+
+- **Tag choice per workflow:** The pattern doc gives the structure. Exact tag strings are best chosen at the point of edit so they reflect the workflow's actual semantics. Implementer should mirror the wording used in the workflow's existing job/step names.
+- **Whether to include PR number, issue number, branch name, or commit SHA in `content`:** Decide per workflow based on what makes the search result useful. Default: include the GitHub run URL, plus the most relevant identifier from the trigger event.
+- **`pages.yml` content shape:** GitHub Pages deployment may not produce a meaningful "content" string from event context. Use a generic "Pages deploy <outcome>" if no better identifier is available; supplement with the deployed URL if the workflow exposes it as an output.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The shape is identical to the sister-repo plan; only chain_key and per-workflow specifics vary.*
+
+Each instrumented workflow gains exactly one new step at the end of its existing job (or each job, when there are multiple parallel jobs whose outcomes both matter). The shape is constant; the contents vary:
+
+```yaml
+- name: Append <event> to MentisDB
+  if: always()
+  env:
+    MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+    MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+    MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+    OUTCOME: ${{ job.status }}
+    RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    # plus event-context vars: PR_NUMBER, PR_TITLE, ISSUE_NUMBER, ISSUE_LABEL, etc.
+  run: |
+    set -euo pipefail
+    case "$OUTCOME" in
+      success)   TYPE="<success-type>"; IMP="<success-imp>" ;;
+      failure)   TYPE="Mistake";        IMP="0.8"           ;;
+      cancelled) TYPE="Mistake";        IMP="0.6"           ;;
+      *)         TYPE="Mistake";        IMP="0.7"           ;;
+    esac
+    PAYLOAD=$(jq -nc \
+      --arg type "$TYPE" \
+      --arg outcome "$OUTCOME" \
+      --arg run_url "$RUN_URL" \
+      --arg imp "$IMP" \
+      '{
+        chain_key: "wgmesh",
+        agent_id: "<workflow-id>",
+        agent_name: "<workflow-id>",
+        thought_type: $type,
+        content: ("<event description with identifiers> — " + $outcome + " (" + $run_url + ")"),
+        tags: ["wgmesh", "<event-type>", $outcome],
+        importance: ($imp | tonumber)
+      }')
+    curl --fail-with-body --silent --show-error --max-time 15 \
+      -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+      -X POST -H 'Content-Type: application/json' \
+      -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+      || echo "::warning::mentisdb append failed (non-fatal)"
+```
+
+Per-workflow variation lives only in: `<event>` (step name), `<workflow-id>` (filename stem), `<success-type>` / `<success-imp>` (per pattern table), `<event description>`, `<event-type>` tag string, identifiers in content.
+
+---
+
+## Implementation Units
+
+- U1. **PR lifecycle workflows (3 files)**
+
+**Goal:** Instrument the three workflows that handle PR lifecycle (open → review/merge → undraft) so each PR's outcome is recorded.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None (org secrets already provisioned).
+
+**Files:**
+- Modify: `.github/workflows/bot-pr-review-merge.yml`
+- Modify: `.github/workflows/copilot-undraft.yml`
+- Modify: `.github/workflows/auto-merge.yml`
+
+**Approach:**
+- For `bot-pr-review-merge.yml`: append at end of the review-merge job. `agent_id="bot-pr-review-merge"`. Success → `TaskComplete` (imp 0.7), failure → `Mistake` (imp 0.8). Content includes PR number + author. Tags: `["wgmesh", "pr-review-merge", $outcome]`.
+- For `copilot-undraft.yml`: append at end of the undraft job. `agent_id="copilot-undraft"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.7). Content includes PR number. Tags: `["wgmesh", "spec-undraft", $outcome]`.
+- For `auto-merge.yml`: append at end of the auto-merge job. `agent_id="auto-merge"`. Success → `TaskComplete` (imp 0.7), failure → `Mistake` (imp 0.8). Content includes PR number + title. Tags: `["wgmesh", "auto-merge", $outcome]`.
+- All three: non-fatal append.
+
+**Patterns to follow:**
+- `.github/workflows/agent-metrics-report.yml` and `.github/workflows/release.yml` — env block, jq payload, curl invocation.
+- Sister-repo PR #610 commit `a612392` — same pattern applied to the equivalent ai-pipeline-template workflows.
+
+**Test scenarios:**
+- Happy path: real bot PR opens → `bot-pr-review-merge` fires → `TaskComplete` thought lands with PR# in content (verifiable by querying chain with `tags_any=["pr-review-merge"]`).
+- Happy path: Copilot draft PR opens → `copilot-undraft` fires → `ActionTaken` thought lands.
+- Happy path: PR ready for auto-merge → `auto-merge` fires → `TaskComplete` thought lands.
+- Edge case: workflow's `if:` gate skips the job (e.g., bot-pr-review-merge filter excludes the PR's author) — append step still runs (`if: always()`) and records the gate-out as success of an empty job. Acceptable.
+- Error path: simulate MentisDB unavailability via `gh workflow run` against a test branch with bad URL — confirm workflow exits 0 with `::warning::` in logs.
+- Integration: full PR lifecycle (bot opens → undraft → review-merge → merge) → all three thoughts present in chain with consistent timing.
+
+**Verification:**
+- All three workflows pass `actionlint` post-edit.
+- After merge, the next bot PR triggers each workflow and corresponding thoughts land in the chain.
+
+---
+
+- U2. **Spec workflow cluster (4 files)**
+
+**Goal:** Instrument the four workflows that drive the spec → approve → build pipeline (parallel to ai-pipeline-template's spec/build cluster, but with wgmesh-specific extras `spec-command` for slash-command handling and `spec-auto-approve` for auto-approval logic).
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `.github/workflows/approve-build.yml`
+- Modify: `.github/workflows/spec-auto-approve.yml`
+- Modify: `.github/workflows/spec-command.yml`
+- Modify: `.github/workflows/spec-merged-build.yml`
+
+**Approach:**
+- For `approve-build.yml`: `agent_id="approve-build"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.7). Content includes PR # + reviewer + review state. Tags: `["wgmesh", "spec-approval", $outcome]`. **Caveat:** trigger is `pull_request_review` — Copilot/App reviews via GITHUB_TOKEN won't fire it (per `github-app-reviews-dont-trigger-workflows.md`). Document in residual notes; not a defect introduced by this plan.
+- For `spec-auto-approve.yml`: `agent_id="spec-auto-approve"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.7). **Do NOT use Correction** — pre-empt the lesson from ai-pipeline-template PR #610 (where spec-validation was initially mis-set to Correction). Content includes PR # + auto-approve decision. Tags: `["wgmesh", "spec-auto-approve", $outcome]`.
+- For `spec-command.yml`: `agent_id="spec-command"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.7). Content includes the slash-command invoked + issue/PR #. Tags: `["wgmesh", "spec-command", $outcome]`.
+- For `spec-merged-build.yml`: `agent_id="spec-merged-build"`. Success → `ActionTaken` (imp 0.5; the actual build happens elsewhere — goose-build is already wired), failure → `Mistake` (imp 0.7). Content includes spec PR # + dispatched build target. Tags: `["wgmesh", "spec-merge-build", $outcome]`.
+- All four: non-fatal append.
+
+**Patterns to follow:**
+- Same as U1.
+
+**Test scenarios:**
+- Happy path: spec PR opened with slash-command → `spec-command` runs → `ActionTaken` lands.
+- Happy path: spec PR validated → `spec-auto-approve` runs → `ActionTaken` lands (NOT Correction — verify thought_type explicitly).
+- Happy path: spec PR approved (human review) → `approve-build` runs → `ActionTaken` lands.
+- Happy path: spec PR merged → `spec-merged-build` dispatches downstream → `ActionTaken` lands.
+- Edge case: `approve-build` triggered by Copilot review — silently skipped per App-actor limitation. Append step doesn't fire because workflow doesn't fire. Document in residual.
+- Error path: spec validation chain fails at any stage → `Mistake` thought lands at the failing workflow; main workflow surfaces failure normally.
+- Integration: full spec lifecycle → all four thoughts present in chain with correct outcome ordering.
+
+**Verification:**
+- All four workflows pass actionlint.
+- A spec PR run produces 4 thoughts (one per workflow in the spec cluster) tagged correctly.
+- spec-auto-approve thought has `thought_type="ActionTaken"` (NOT Correction) — verifiable via direct chain query.
+
+---
+
+- U3. **Issue lifecycle workflows (3 files)**
+
+**Goal:** Instrument the three workflows that handle issue triage, impl-PR closure, and issue housekeeping so the issue → spec → impl → close arc is recorded end-to-end.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `.github/workflows/copilot-triage.yml`
+- Modify: `.github/workflows/impl-merged-close.yml`
+- Modify: `.github/workflows/close-resolved-issues.yml`
+
+**Approach:**
+- For `copilot-triage.yml`: `agent_id="copilot-triage"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.7). Content includes issue # + triggering label. Tags: `["wgmesh", "issue-triage", $outcome]`.
+- For `impl-merged-close.yml`: `agent_id="impl-merged-close"`. Success → `TaskComplete` (imp 0.7) — closing an impl PR completes a unit of work, failure → `Mistake` (imp 0.7). Content includes PR # + linked issue # (extracted from PR title via grep `Issue #N`). Tags: `["wgmesh", "impl-close", $outcome]`.
+- For `close-resolved-issues.yml`: `agent_id="close-resolved-issues"`. Success → `ActionTaken` (imp 0.5; this is housekeeping, not a "task complete" event), failure → `Mistake` (imp 0.7). Content includes count of issues closed (if exposed as job output) or just outcome. Tags: `["wgmesh", "issue-housekeeping", $outcome]`.
+- All three: non-fatal append.
+
+**Patterns to follow:**
+- Same as U1.
+- For `impl-merged-close.yml` ISSUE_NUM extraction: copy the pipefail-safe pattern from ai-pipeline-template's `impl-merged-close.yml`:
+  ```bash
+  ISSUE_NUM=$(echo "$PR_TITLE" | grep -oE 'Issue #[0-9]+' | grep -oE '[0-9]+' | head -1 || echo "unknown")
+  ```
+  Verified correct under `set -euo pipefail` per the sister-repo PR #610 review (correctness + reliability + testing reviewers all confirmed).
+
+**Test scenarios:**
+- Happy path: file an issue with `bug` label → `copilot-triage` fires → `ActionTaken` thought lands with issue # in content.
+- Happy path: bot opens impl PR → human merges → `impl-merged-close` fires → `TaskComplete` thought lands.
+- Happy path: scheduled cleanup runs → `close-resolved-issues` fires → `ActionTaken` thought lands with summary.
+- Edge case: PR title without `Issue #N` → ISSUE_NUM extraction returns `"unknown"`, payload still validates and lands.
+- Edge case: triage workflow's `if:` gate skips the job (e.g., issue already has `copilot-triaging` label) — `if: always()` still runs the append, recording a no-op run as success.
+- Error path: `gh` token expired → workflow fails → `Mistake` thought lands; original failure surfaces in logs.
+- Integration: full issue → triage → spec → build → impl → close cycle on a test issue → all U3 thoughts present plus the U2 spec-pipeline thoughts.
+
+**Verification:**
+- All three workflows pass actionlint.
+- A real issue lifecycle produces all three thoughts tagged correctly.
+
+---
+
+- U4. **Build / deploy workflows (3 files)**
+
+**Goal:** Instrument the three workflows that build/deploy artifacts (container, pages, DNS) so deploy-side observability has a chain entry per dispatch.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `.github/workflows/docker-build.yml`
+- Modify: `.github/workflows/pages.yml`
+- Modify: `.github/workflows/dns-update.yml`
+
+**Approach:**
+- For `docker-build.yml`: `agent_id="docker-build"`. Success → `TaskComplete` (imp 0.7) — image successfully built/pushed, failure → `Mistake` (imp 0.8). Content includes commit SHA + image tag/digest if exposed, plus build duration if available. Tags: `["wgmesh", "docker-build", $outcome]`.
+- For `pages.yml`: `agent_id="pages"`. Success → `TaskComplete` (imp 0.6) — pages successfully deployed, failure → `Mistake` (imp 0.7). Content includes deploy URL + commit SHA. Tags: `["wgmesh", "pages-deploy", $outcome]`.
+- For `dns-update.yml`: `agent_id="dns-update"`. Success → `ActionTaken` (imp 0.5; DNS sync is incremental, not a release), failure → `Mistake` (imp 0.7). Content includes record count or zone updated. Tags: `["wgmesh", "dns-update", $outcome]`.
+- All three: non-fatal append.
+
+**Patterns to follow:**
+- `.github/workflows/release.yml` — release-event reference for build/deploy idiom (TaskComplete on success, fatal append for tag publish — but adjust to non-fatal for these higher-frequency events).
+
+**Test scenarios:**
+- Happy path: push to main → `docker-build` runs → `TaskComplete` thought lands with image tag in content.
+- Happy path: docs change to main → `pages` runs → `TaskComplete` thought lands with deploy URL in content.
+- Happy path: DNS config change → `dns-update` runs → `ActionTaken` thought lands.
+- Error path: docker build fails (registry auth, network) → `Mistake` thought lands; CI status surfaces failure.
+- Edge case: workflow has multiple parallel jobs (e.g., docker-build for amd64+arm64) — append step in EACH job. Each emits its own thought. Acceptable: queries with `tags_any=["docker-build"]` get one thought per arch per build.
+- Integration: a single push to main may trigger multiple of these workflows simultaneously — confirm chain receives one thought per workflow per dispatch.
+
+**Verification:**
+- All three workflows pass actionlint.
+- The next push to main triggers each workflow and produces the expected thought.
+
+---
+
+- U5. **Infra / board / quality workflows (3 files)**
+
+**Goal:** Instrument the three workflows that manage infrastructure sync, project board sync, and goose review (pre-build quality gate).
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `.github/workflows/hetzner-integration.yml`
+- Modify: `.github/workflows/board-sync.yml`
+- Modify: `.github/workflows/goose-review.yml`
+
+**Approach:**
+- For `hetzner-integration.yml`: `agent_id="hetzner-integration"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.8) — Hetzner failures matter (per recent PR #611 hcloud-volume gotcha, infra plan failures should be loud in the chain). Content includes resource type / change summary if exposed. Tags: `["wgmesh", "hetzner-sync", $outcome]`.
+- For `board-sync.yml`: `agent_id="board-sync"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.7). Content includes count of items synced (if exposed) or just outcome. Tags: `["wgmesh", "board-sync", $outcome]`.
+- For `goose-review.yml`: `agent_id="goose-review"`. Success → `ActionTaken` (imp 0.5; review verdict produced), failure → `Mistake` (imp 0.7). **Do NOT use Correction** (review pass produces a verdict, doesn't fix a Mistake). Content includes PR # + review summary if exposed. Tags: `["wgmesh", "goose-review", $outcome]`.
+- All three: non-fatal append.
+
+**Patterns to follow:**
+- Same as U1.
+
+**Test scenarios:**
+- Happy path: scheduled hetzner-integration run → `ActionTaken` thought lands.
+- Happy path: PR opened → `board-sync` runs → `ActionTaken` thought lands.
+- Happy path: spec PR opened → `goose-review` runs → `ActionTaken` thought lands.
+- Error path: hetzner-integration fails (Hetzner API down, terraform error) → `Mistake` thought lands with imp 0.8 (high importance — infra failures are loud).
+- Edge case: goose-review timeout or empty verdict → workflow may succeed-with-warnings; thought_type still ActionTaken; content reflects the situation.
+- Integration: a spec PR triggers `goose-review` + `spec-command` + `spec-auto-approve` + `approve-build` (potentially) — confirm all four thoughts present and tagged distinctly.
+
+**Verification:**
+- All three workflows pass actionlint.
+- Next natural trigger of each produces an expected thought.
+
+---
+
+- U6. **Post-merge verification dispatch + chain query**
+
+**Goal:** Confirm the rollout works end-to-end by dispatching one workflow per cluster after merge and querying the wgmesh chain for the resulting thoughts.
+
+**Requirements:** R8
+
+**Dependencies:** U1, U2, U3, U4, U5 all merged to `main`.
+
+**Files:**
+- No file changes. Verification is operational.
+
+**Approach:**
+- After merge, manually trigger via `gh workflow run` (or wait for natural triggers) at least one workflow per cluster:
+  - U1 cluster: any of the three (auto-merge fires on the merge of this PR itself, providing natural verification).
+  - U2 cluster: dispatch `spec-command` against an existing closed spec PR or wait for next bot spec.
+  - U3 cluster: file a test issue with `needs-triage` label, then close manually.
+  - U4 cluster: trigger `pages` via `gh workflow run pages.yml` or wait for next docs commit.
+  - U5 cluster: dispatch `goose-review` against an existing PR, or wait for `hetzner-integration` scheduled run.
+- For each, run the verification curl from `reference_mentisdb_ci_integration_pattern.md` Verification queries section, scoped to `chain_key=wgmesh` and the relevant tag, and confirm the run_url in content matches the dispatched run.
+- Cross-check no `::warning::mentisdb append failed` lines in any of the dispatched runs (would indicate connectivity/auth/payload issue worth investigating, even though non-fatal).
+
+**Test scenarios:**
+- Test expectation: none — operational verification, no code changes.
+
+**Verification:**
+- For each of the five clusters, at least one thought appears in the wgmesh chain with the run_url matching a dispatched run.
+- No workflow failed due to mentisdb append (Actions tab green; warnings in logs investigated if present but workflow itself green).
+- The cross-repo continuity goal is met: querying `chain_key=wgmesh tags_any=["pr-review-merge","spec-approval","docker-build","goose-review","hetzner-sync"]` returns ≥5 distinct event-type thoughts within 24h of merge.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Each instrumented workflow gains one trailing step. No cross-workflow coupling, no shared state. Failure of the append step does not cascade.
+- **Error propagation:** Append failures are absorbed by `|| echo "::warning::..."`. The workflow's primary outcome (build pass/fail, merge success, deploy verdict, etc.) is unaffected.
+- **State lifecycle risks:** None. MentisDB writes are append-only thoughts. Risk if a workflow retries: duplicate thoughts. Mitigation: pattern doc accepts this; queries can dedup by `run_url`.
+- **API surface parity:** No external API surface change. Only consumer of new thoughts is MentisDB, already serving wgmesh's existing 3 instrumented workflows + ai-pipeline-template's 11.
+- **Integration coverage:** Integration is a single curl POST. No unit tests meaningful. End-to-end verification via U6.
+- **Unchanged invariants:** `agent-metrics-report.yml`, `release.yml`, `goose-build.yml` are not modified. `sync-labels.yml` remains uninstrumented by design. Org secret `MENTISDB_*` values, visibility, and rotation cadence unchanged. Workflow trigger conditions, permissions blocks, concurrency groups unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| MentisDB outage during rollout would emit `::warning::` on every workflow run across both repos. | Non-fatal append + `--max-time 15` curl timeout. Workflows still pass. ai-pipeline-template's `mentisdb-smoketest.yml` daily canary surfaces sustained outage as its own failure. |
+| `approve-build.yml` triggered by Copilot review silently skips per App-actor limitation. | Pre-existing limitation, not introduced by this plan. Document in residual review findings. Future migration to `workflow_run` on `spec-auto-approve` is a separate concern. |
+| 16 workflows × ~30-40 LOC = ~500 LOC duplication; pattern doc + sister repo also inline. | Composite-action extraction explicitly deferred. Re-evaluate at 13+ workflows in any single repo OR breaking MentisDB API change. |
+| Pre-emptive Correction misuse: implementer might default to Correction on success for `spec-auto-approve` or `goose-review`. | Plan explicitly documents the lesson from ai-pipeline-template PR #610 review. Implementer must use ActionTaken on success for all 16 workflows; Correction is reserved for "fix to a Mistake thought". |
+| Implementer might forget `if: always()` on a step, causing failure thoughts to never land. | Per-unit Approach explicitly states `if: always()`. U6 verification on intentionally failed test runs catches missing thoughts. |
+| `pages.yml` and `dns-update.yml` may have multi-job structures that need per-job append (not just per-workflow). | Implementer should inspect each workflow's job count before adding append. If multi-job, append in each terminal job; if single-job, append once. Plan does not mandate one-step-per-workflow rigidly. |
+
+---
+
+## Documentation / Operational Notes
+
+- After rollout, update `~/.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/reference_mentisdb_ci_integration_pattern.md` "Onboarding a new repo" section to reflect: 19 wgmesh workflows instrumented (was 3), and 11 ai-pipeline-template workflows instrumented (was 3). Defer the memory update to post-merge.
+- No runbook changes — failure modes are the same as before, just now also visible in MentisDB.
+- No monitoring changes — existing GitHub Actions failure notifications remain primary alert channel; MentisDB is supplementary.
+- Phase 2 (secondary repos: coroot-cicd, chimney, tvcentras) is a separate plan, requires `gh secret set ... --visibility selected --repos ai-pipeline-template,wgmesh,<new-repo>` widening first. Defer.
+
+---
+
+## Sources & References
+
+- **Pattern doc (authoritative):** `~/.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/reference_mentisdb_ci_integration_pattern.md`
+- **Sister-repo plan:** `ai-pipeline-template/docs/plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md`
+- **Sister-repo PR #610** (squash commit `a612392`) — 10-workflow instrumentation, structurally identical
+- **Sister-repo heal PR #611** (commit `190844e`) — terraform-side fix unrelated to this plan
+- **wgmesh reference impls:** `.github/workflows/agent-metrics-report.yml`, `.github/workflows/release.yml`, `.github/workflows/goose-build.yml`
+- **Org secrets inventory:** `~/.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/reference_org_secrets_inventory.md`
+- **Auth gotcha:** `~/.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/feedback_mentisdb_no_rest_auth.md`
+- **Lesson from sister-repo review:** `ai-pipeline-template/docs/residual-review-findings/task-le-volume-and-review-batch.md` — items res-001 (agent_id↔tag), res-002 (App-actor trigger gap), res-003 (composite-action threshold)

--- a/docs/pulse-reports/2026-05-09_05-52.md
+++ b/docs/pulse-reports/2026-05-09_05-52.md
@@ -1,0 +1,54 @@
+# wgmesh pulse — 2026-05-09 05:52 (window 24h)
+
+Window: 2026-05-08 05:37 → 2026-05-09 05:37 UTC. Diff vs prior pulse 2026-05-08_20-30 (~9h ago) where useful.
+
+## Headlines
+
+- **Auto-merge bot regression: PR #577 merged then reverted via #580.** Goose-implemented Tier 5 NAT was *decoration not implementation* — `test_t28_nat_relay_required` and `test_t29_nat_route_flap` shipped to main but Tier 5 runner stayed at `TOTAL_TESTS_IN_TIER=3` and `T25–T27` calls. Auto-merge-bot (`bot-pr-review-merge.yml`) treated Copilot's `state: COMMENTED` as approval-equivalent and admin-merged anyway with 13 unresolved findings. Validates the L4 gate's reason for existence. Same anti-pattern PR #570 is fixing structurally.
+- **PR #570 in heavy review iteration — 6 distinct Copilot rounds, 12 `fix(review)` commits total.** All checks green at this snapshot, but the PR has not merged in 24h. Review velocity issue, not a code-quality issue.
+- **Conversion-path: #585 spec opened, #586 PR closed-without-merge.** #586 was a feat for cloudroof pricing slide with 3 Polar CTAs — closed 2026-05-08 18:09 with no apparent merge. Reason not on PR. #585 ("spec: define implementation plan for Polar checkout CTAs on wgmesh.dev") still spec-stage. #584 (the original CTA gap) remains open.
+- **Feature-ledger PIM landed on local branch `feat/feature-ledger-pim`** — 7 commits (foundational docs + U1-U6) authored by Codex via background rescue. NOT pushed. NOT reviewed yet.
+
+## Usage
+
+| Metric | Value | Δ vs 24h ago |
+|---|---|---|
+| Stars | 11 | 0 |
+| Issues opened (24h) | 8 | — |
+| Issues closed (24h) | 4 | — |
+| PRs opened (24h) | 14 | — |
+| PRs merged (24h) | 6 | — |
+| PRs reverted (24h) | 1 (#580 reverts #577) | new |
+| primary_engagement_event | no data (chimney pending) | no change |
+| weekly_active_meshes | no data (chimney pending) | no change |
+| time_to_mesh_p50 | no data (synthetic probe pending) | no change |
+| Paying customers | not queried | no change |
+
+Strategy metrics still 4-of-5 dark. Same gap as 2026-05-06 + 2026-05-08 pulses. No instrumentation work shipped in this window despite #585 spec opening for the conversion path.
+
+## System performance
+
+PR #570 checks: all green. Workflow health on main since last pulse:
+
+| Workflow | Status |
+|---|---|
+| Build and Push Docker Images | mixed — one transient Docker Hub 504 (resolved on rerun) |
+| CodeQL | clean |
+| Auto-merge on CI pass | active and over-eager (see #577 incident) |
+| `Implementation Merged — Close Issue` | first run on `pull_request_target: closed` (post-#582) — succeeded on #582 self-merge, valid signal that #582's swap works |
+| Spec / Goose / Copilot triage | many Copilot/* branches active; minor `action_required` count, not blocking |
+
+Concrete failures in window:
+- **#577 post-merge regression caught by human, not CI.** PR #570's L4 gate (predicate-test detection) would have prevented this exact pattern.
+- **Auto-merge bot bug.** `bot-pr-review-merge.yml` interprets Copilot review `state: COMMENTED` as approval-equivalent. Real bug; should be filed as separate issue.
+
+## Followups
+
+1. **File `bot-pr-review-merge.yml` as bug** — auto-merge bot must require Copilot `state: APPROVED`, not `COMMENTED`. The #577→#580 incident is the immediate cost. Without fix, the next Goose decoration ships the same way.
+2. **Push + open PR for `feat/feature-ledger-pim`** — Codex finished local work. 7 commits ready. Code-review pass before pushing recommended. After PR opens, #571 will appear in `STATUS.md` gap roster as the first concrete test of the inventory feature.
+3. **Resolve #570 review velocity** — 6 Copilot review rounds suggests the auto-reviewer is loop-looping. Either (a) Copilot is finding real issues each round, or (b) the bot's calibration is too low. Check finding-uniqueness across rounds 3-6 to decide.
+4. **Investigate #586 silent close** — pricing-slide PR closed with no merge and no documented reason. Either superseded by #585 spec or rolled into something else; surface the rationale on the PR or reopen if dropped accidentally.
+5. **Tier 5 NAT properly: PR #575 spec is open.** With #577 reverted, #575 becomes the live track. Block any future #571 implementation PR on a passing test that actually changes Tier 5's `TOTAL_TESTS_IN_TIER` count from 3 to 5+.
+6. **Goose Implementation health** — fix `bot-pr-review-merge.yml` first (item 1) so further Goose runs don't auto-ship decoration. Until then, treat Goose impl PRs as needing manual review even with `app/pupabobas` greenlight.
+
+Saved to `docs/pulse-reports/2026-05-09_05-52.md`.

--- a/docs/pulse-reports/2026-05-09_17-02.md
+++ b/docs/pulse-reports/2026-05-09_17-02.md
@@ -1,0 +1,52 @@
+# wgmesh pulse — 2026-05-09 17:02 (window 3h)
+
+Window: 2026-05-09 14:00 → 2026-05-09 17:00 UTC. Tight 3h diff vs prior pulse `2026-05-09_05-52.md`.
+
+## Headlines
+
+- **Issue #595 filed** — `bot-pr-review-merge.yml` Copilot-COMMENTED-as-approval bug. Tracker for the merge-policy fix; cites #577 and #589 as concrete instances.
+- **PR #596 opened** — surgical follow-up for the 5 PIM bugs that landed via PR #589 admin-merge. 5 commits, all CI checks green, drift check passes.
+- **Bot has not tripped on PR #596 yet** — `review-merge` job ran at 13:54 and decided not to merge despite Copilot already submitting `state: COMMENTED` at 13:58. Either the bot is slower than the review and would still trip later, or there is a check I'm not seeing. Watch.
+- **Copilot found 4 new findings on PR #596** — fix-PR introduced its own gaps.
+
+## Usage
+
+| Metric | Value | Δ vs 3h ago |
+|---|---|---|
+| Open PRs | 9 | unchanged |
+| PRs opened (3h) | 1 (#596) | new |
+| Issues opened (3h) | 1 (#595) | new |
+| #589 status | MERGED 08:08 with 5 unresolved findings | merged silently 3h after prior pulse |
+| #596 status | OPEN; 4 new Copilot findings (different from #589's) | new |
+| #570 status | still OPEN, awaiting review settlement | unchanged |
+| primary_engagement_event / weekly_active_meshes / time_to_mesh_p50 | no data (instrumentation pending) | unchanged from 2026-05-06 |
+
+## System performance
+
+PR #596 checks (all green):
+
+| Check | State |
+|---|---|
+| `Analyze (go/javascript-typescript/python)` | pass |
+| `build-and-push` | pass |
+| `review-merge` | pass (did not auto-merge — possible bot policy fix already underway, or just timing) |
+| `status-check` (new from PR #589 PIM) | **pass — first real exercise of the PIM lint + drift workflow** |
+| Other Copilot/Goose triage workflows | skipping (correct — PR is human-authored) |
+
+## New Copilot findings on PR #596
+
+| # | File | Issue |
+|---|---|---|
+| 1 | `pkg/crypto/envelope_compat_test.go:77` | Test hardcodes `v1` despite regen path being keyed off `EnvelopeCapabilityVersion` — tests will fail/stop exercising the new logic when version bumps. Same bug class as the one #596 was supposed to fix. |
+| 2 | `pkg/crypto/envelope_compat_test.go:111` | `filepath.Glob` returns lexicographic order; `v10` sorts before `v2`. Replay order breaks at version 10+. Fix: parse version int, sort numerically. |
+| 3 | `cmd/status-gen/render.go:56` | Summary counter increments `stats.provisional` for `StatusProvisional` only; ignores `StatusImplementable`. Wrong count once any feature is implementable. |
+| 4 | `eidos/eidosmeta/meta.go:17` | Status enum allows `implemented`/`implementable`/`provisional` but origin requirements doc + plan also define `deprecated`. Contract mismatch. |
+
+## Followups
+
+1. **Fix the 4 PR #596 findings before bot trips.** All four are surgical. Recommend bundled `fix(review): address PR #596 Copilot findings` commit. Same recipe as the 5-finding fix that produced #596 itself.
+2. **Issue #595 (bot policy) remains the upstream cause.** Until it lands, every fix-PR risks the same auto-merge slip. Prioritize over per-PR finding cleanup if signal continues.
+3. **PR #570 review-velocity still unresolved.** No movement in 12h. Check whether Copilot is still iterating or whether human attention is needed.
+4. **Strategy metrics still 4-of-5 dark.** No change since 2026-05-06. Three pulses now flagging this; not landing on its own.
+
+Saved to `docs/pulse-reports/2026-05-09_17-02.md`.

--- a/docs/pulse-reports/2026-05-09_20-32.md
+++ b/docs/pulse-reports/2026-05-09_20-32.md
@@ -1,0 +1,48 @@
+# wgmesh pulse — 2026-05-09 20:32 (window 4h)
+
+Window: 2026-05-09 16:30 → 2026-05-09 20:30 UTC. Diff vs prior pulse `2026-05-09_17-02.md`.
+
+## Headlines
+
+- **Bug in the prior pulse:** I claimed PR #596 had not auto-merged yet at 17:02. False. PR #596 merged at 15:33 UTC, ~90 minutes before the prior pulse. The 4 Copilot findings on #596 are live on main since then. Lesson: always check `mergedAt` before asserting merge state.
+- **PR #597 opened (bot policy fix).** `fix/bot-merge-require-approved-595`, 1 commit, +283/-15 across `pr-review-merge.sh` + new test harness + workflow YAML comment. Implements GraphQL `latestReviews` verdict computation, Step 6 guardrail re-check, pre-merge audit comment. 9-scenario test harness green.
+- **Codex usage limit hit until 2026-05-12 21:38 UTC.** PR #597 implemented directly without `codex:codex-rescue` dispatch. Force-majeure exception to the global plan-opus-execute-codex rule; documented.
+- **PR #597 itself reviewed by Copilot at 17:47 with state=COMMENTED (5 inline comments).** Bot run completed but did NOT merge — possibly the unresolved-threads retry loop blocked it, or Copilot's threads ARE resolvable and the count came back >0. Need to investigate why the bot blocked here vs. shipped #596 / #589 / #577. The protective effect is welcome but the inconsistency is concerning.
+
+## Usage
+
+| Metric | Value | Δ vs 4h ago |
+|---|---|---|
+| Open PRs | 9 | unchanged |
+| PRs opened (4h) | 1 (#597) | new |
+| Issues opened (4h) | 0 | — |
+| #597 status | OPEN, Copilot COMMENTED at 17:47, bot did NOT merge | new |
+| #596 status | MERGED at 15:33 with 4 unresolved findings on main | corrected from prior pulse |
+| #570 status | still OPEN, no movement in 8h | unchanged |
+| Strategy metrics | 4-of-5 dark | unchanged across 4 pulses now |
+
+## System performance
+
+PR #597 checks:
+
+| Check | State |
+|---|---|
+| `Analyze (go/javascript-typescript/python)` | pass |
+| `build-and-push` | pass |
+| `status-check` (PIM lint workflow shipped via #589) | **pass — protecting the bot fix's own commit which doesn't touch eidos/** |
+| `Bot PR Review and Merge` | completed=success, did NOT auto-merge |
+
+`status-check` validating a non-eidos PR is the right shape — workflow only fires meaningful diags on `eidos/*.md` changes, otherwise no-ops cleanly. First evidence that the PIM foundation is doing its job.
+
+## Followups
+
+1. **Investigate why bot blocked PR #597 but shipped #596 / #589 / #577.** All four had the same review shape (Copilot COMMENTED, inline findings). Either:
+   - The unresolved-threads retry loop blocked here and escalated after MAX_RETRY_COUNT, but didn't catch #596 / #589 / #577 for reasons unknown, OR
+   - Some other guardrail is firing inconsistently.
+   Read the audit log + escalation comment on #597 to find out. If the loop is working sometimes, the actual bug surface may be narrower than #595 describes — possibly only a subset of state combinations slip.
+2. **Maintainer manual APPROVE on PR #597 to land the policy fix.** Until #597 merges, every other PR ships under the old policy.
+3. **PR #596's 4 live findings.** Either repair via #598 (after #597 lands so reviewer signal matters) or open as 4 individual tracked issues. Lean repair.
+4. **PR #570 review velocity still stuck.** No movement in 8+h. Different pathology from #596 chain. Check whether Copilot is iterating or human attention is needed.
+5. **Strategy metrics still 4-of-5 dark across 4 consecutive pulses.** Not landing on its own. Either accept the gap as deliberate or schedule explicit instrumentation work.
+
+Saved to `docs/pulse-reports/2026-05-09_20-32.md`.

--- a/evolution/wgmesh-cdn-slides.html.bak
+++ b/evolution/wgmesh-cdn-slides.html.bak
@@ -1,0 +1,1116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>wgmesh — Encrypted Mesh Networking for Self-Hosters</title>
+    <meta name="description" content="Build encrypted WireGuard mesh networks in minutes. Self-hosted, decentralized, NAT-traversing. Connect your homelab, remote servers, and edge nodes with a single shared secret.">
+    <meta name="keywords" content="WireGuard mesh, self-hosted VPN, mesh networking, homelab, NAT traversal, decentralized, DHT discovery">
+    <meta property="og:title" content="wgmesh — Encrypted Mesh Networking for Self-Hosters">
+    <meta property="og:description" content="Build encrypted WireGuard mesh networks in minutes. No coordination server. No manual key exchange. Just a shared secret.">
+    <meta property="og:url" content="https://cloudroof.eu/">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="wgmesh — Encrypted Mesh Networking">
+    <meta name="twitter:description" content="Self-hosted WireGuard mesh. Share a secret, build a mesh.">
+    <link rel="canonical" href="https://cloudroof.eu/">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Space+Grotesk:wght@400;700&family=Outfit:wght@300;400;600;800&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-dark: #0a0a0f;
+            --bg-card: #12121a;
+            --bg-accent: #1a1a2e;
+            --text-primary: #e6edf3;
+            --text-muted: #7d8590;
+            --green: #00ff88;
+            --blue: #00d4ff;
+            --purple: #a855f7;
+            --orange: #ff6b35;
+            --yellow: #fbbf24;
+            --red: #ff6b6b;
+            --pink: #ec4899;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html {
+            scroll-behavior: smooth;
+            scroll-snap-type: y mandatory;
+        }
+
+        body {
+            font-family: 'Outfit', sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            line-height: 1.6;
+            overflow-x: hidden;
+        }
+
+        /* Slide container */
+        .slide {
+            min-height: 100vh;
+            padding: 4rem;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            scroll-snap-align: start;
+            position: relative;
+            overflow: hidden;
+        }
+
+        /* Backgrounds */
+        .slide::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            opacity: 0.4;
+            pointer-events: none;
+        }
+
+        .slide-1::before {
+            background: 
+                radial-gradient(ellipse at 20% 80%, rgba(0, 255, 136, 0.15) 0%, transparent 50%),
+                radial-gradient(ellipse at 80% 20%, rgba(0, 212, 255, 0.15) 0%, transparent 50%);
+        }
+
+        .slide-2::before {
+            background: 
+                radial-gradient(ellipse at 50% 50%, rgba(168, 85, 247, 0.1) 0%, transparent 60%);
+        }
+
+        .slide-3::before {
+            background: 
+                radial-gradient(ellipse at 30% 70%, rgba(255, 107, 53, 0.12) 0%, transparent 50%),
+                radial-gradient(ellipse at 70% 30%, rgba(251, 191, 36, 0.12) 0%, transparent 50%);
+        }
+
+        /* Grid pattern overlay */
+        .grid-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-image: 
+                linear-gradient(rgba(255,255,255,0.02) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(255,255,255,0.02) 1px, transparent 1px);
+            background-size: 60px 60px;
+            pointer-events: none;
+        }
+
+        .content {
+            position: relative;
+            z-index: 1;
+            max-width: 1400px;
+            margin: 0 auto;
+            width: 100%;
+        }
+
+        /* Typography */
+        h1 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: clamp(3rem, 8vw, 6rem);
+            font-weight: 700;
+            line-height: 1.1;
+            margin-bottom: 1.5rem;
+            background: linear-gradient(135deg, var(--green) 0%, var(--blue) 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        h2 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: clamp(2rem, 5vw, 3.5rem);
+            font-weight: 700;
+            margin-bottom: 2rem;
+            color: var(--text-primary);
+        }
+
+        h3 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+            color: var(--green);
+        }
+
+        .subtitle {
+            font-size: 1.5rem;
+            color: var(--text-muted);
+            max-width: 600px;
+            font-weight: 300;
+        }
+
+        .tag {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background: rgba(0, 255, 136, 0.1);
+            border: 1px solid rgba(0, 255, 136, 0.3);
+            border-radius: 100px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.875rem;
+            color: var(--green);
+            margin-bottom: 1rem;
+        }
+
+        /* Code blocks */
+        .code-block {
+            background: var(--bg-card);
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 12px;
+            padding: 1.5rem;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.9rem;
+            overflow-x: auto;
+            margin: 1rem 0;
+        }
+
+        .code-block .comment { color: var(--text-muted); }
+        .code-block .keyword { color: var(--purple); }
+        .code-block .string { color: var(--green); }
+        .code-block .number { color: var(--orange); }
+
+        /* Cards */
+        .card-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 1.5rem;
+            margin-top: 2rem;
+        }
+
+        .card {
+            background: var(--bg-card);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 16px;
+            padding: 2rem;
+            transition: all 0.3s ease;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 3px;
+            background: linear-gradient(90deg, var(--green), var(--blue));
+            opacity: 0;
+            transition: opacity 0.3s ease;
+        }
+
+        .card:hover {
+            border-color: rgba(0, 255, 136, 0.3);
+            transform: translateY(-4px);
+        }
+
+        .card:hover::before {
+            opacity: 1;
+        }
+
+        .card-icon {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .card h4 {
+            font-size: 1.25rem;
+            margin-bottom: 0.75rem;
+            color: var(--text-primary);
+        }
+
+        .card p {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+        }
+
+        /* Architecture diagram */
+        .architecture {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            margin: 2rem 0;
+        }
+
+        .arch-layer {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            padding: 1.5rem;
+            background: var(--bg-card);
+            border-radius: 12px;
+            border-left: 4px solid;
+            animation: slideIn 0.5s ease forwards;
+            opacity: 0;
+            transform: translateX(-20px);
+        }
+
+        .arch-layer:nth-child(1) { border-color: var(--blue); animation-delay: 0.1s; }
+        .arch-layer:nth-child(2) { border-color: var(--green); animation-delay: 0.2s; }
+        .arch-layer:nth-child(3) { border-color: var(--purple); animation-delay: 0.3s; }
+        .arch-layer:nth-child(4) { border-color: var(--orange); animation-delay: 0.4s; }
+        .arch-layer:nth-child(5) { border-color: var(--yellow); animation-delay: 0.5s; }
+
+        @keyframes slideIn {
+            to {
+                opacity: 1;
+                transform: translateX(0);
+            }
+        }
+
+        .arch-label {
+            min-width: 140px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .arch-content {
+            flex: 1;
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .arch-node {
+            background: rgba(255,255,255,0.05);
+            padding: 0.75rem 1.25rem;
+            border-radius: 8px;
+            font-size: 0.9rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .arch-node.highlight {
+            background: rgba(0, 255, 136, 0.15);
+            border: 1px solid rgba(0, 255, 136, 0.3);
+        }
+
+        /* Flow arrows */
+        .flow-connector {
+            display: flex;
+            justify-content: center;
+            padding: 0.5rem 0;
+            color: var(--text-muted);
+            font-size: 1.5rem;
+        }
+
+        /* Table */
+        .comparison-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 2rem 0;
+            font-size: 0.95rem;
+        }
+
+        .comparison-table th,
+        .comparison-table td {
+            padding: 1rem 1.5rem;
+            text-align: left;
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+        }
+
+        .comparison-table th {
+            background: var(--bg-card);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .comparison-table tr:hover td {
+            background: rgba(255,255,255,0.02);
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 100px;
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+
+        .badge-green { background: rgba(0, 255, 136, 0.15); color: var(--green); }
+        .badge-blue { background: rgba(0, 212, 255, 0.15); color: var(--blue); }
+        .badge-purple { background: rgba(168, 85, 247, 0.15); color: var(--purple); }
+        .badge-orange { background: rgba(255, 107, 53, 0.15); color: var(--orange); }
+
+        /* Network diagram */
+        .network-diagram {
+            display: grid;
+            grid-template-rows: auto auto auto auto auto;
+            gap: 0;
+            padding: 2rem;
+            background: var(--bg-card);
+            border-radius: 16px;
+            margin: 2rem 0;
+            position: relative;
+        }
+
+        .diagram-row {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 2rem;
+            padding: 1rem 0;
+            position: relative;
+        }
+
+        .diagram-node {
+            background: var(--bg-accent);
+            padding: 1rem 1.5rem;
+            border-radius: 12px;
+            text-align: center;
+            min-width: 120px;
+            border: 1px solid rgba(255,255,255,0.1);
+            position: relative;
+            z-index: 2;
+        }
+
+        .diagram-node.dns { border-color: var(--blue); }
+        .diagram-node.user { border-color: var(--purple); }
+        .diagram-node.edge { border-color: var(--orange); }
+        .diagram-node.mesh { 
+            border-color: var(--green); 
+            background: rgba(0, 255, 136, 0.1);
+            min-width: 200px;
+        }
+        .diagram-node.origin { border-color: var(--yellow); }
+
+        .diagram-node-label {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            margin-bottom: 0.25rem;
+            font-family: 'JetBrains Mono', monospace;
+        }
+
+        .diagram-node-title {
+            font-weight: 600;
+            font-size: 0.9rem;
+        }
+
+        .diagram-arrow {
+            color: var(--text-muted);
+            font-size: 1.5rem;
+            display: flex;
+            justify-content: center;
+            padding: 0.25rem 0;
+        }
+
+        /* Two legs visualization */
+        .two-legs {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 2rem;
+            margin: 2rem 0;
+        }
+
+        .leg {
+            background: var(--bg-card);
+            border-radius: 16px;
+            padding: 2rem;
+            border: 2px solid;
+        }
+
+        .leg.public { border-color: var(--orange); }
+        .leg.mesh { border-color: var(--green); }
+
+        .leg h4 {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .leg-icon {
+            width: 40px;
+            height: 40px;
+            border-radius: 10px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.25rem;
+        }
+
+        .leg.public .leg-icon { background: rgba(255, 107, 53, 0.2); }
+        .leg.mesh .leg-icon { background: rgba(0, 255, 136, 0.2); }
+
+        /* Navigation */
+        .nav {
+            position: fixed;
+            right: 2rem;
+            top: 50%;
+            transform: translateY(-50%);
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            z-index: 100;
+        }
+
+        .nav-dot {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: rgba(255,255,255,0.2);
+            border: none;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .nav-dot:hover,
+        .nav-dot.active {
+            background: var(--green);
+            transform: scale(1.3);
+        }
+
+        /* Slide counter */
+        .slide-counter {
+            position: fixed;
+            bottom: 2rem;
+            left: 2rem;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            z-index: 100;
+        }
+
+        /* Progress bar */
+        .progress {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 3px;
+            background: linear-gradient(90deg, var(--green), var(--blue));
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 2rem;
+            }
+            
+            .two-legs {
+                grid-template-columns: 1fr;
+            }
+
+            .nav {
+                display: none;
+            }
+        }
+
+        /* Animations */
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+
+        .pulse {
+            animation: pulse 2s ease-in-out infinite;
+        }
+
+        @keyframes float {
+            0%, 100% { transform: translateY(0); }
+            50% { transform: translateY(-10px); }
+        }
+
+        .float {
+            animation: float 3s ease-in-out infinite;
+        }
+
+        /* Bullet points */
+        .bullet-list {
+            list-style: none;
+            margin: 1.5rem 0;
+        }
+
+        .bullet-list li {
+            padding: 0.75rem 0;
+            padding-left: 2rem;
+            position: relative;
+            color: var(--text-muted);
+        }
+
+        .bullet-list li::before {
+            content: '→';
+            position: absolute;
+            left: 0;
+            color: var(--green);
+            font-weight: bold;
+        }
+
+        .bullet-list li strong {
+            color: var(--text-primary);
+        }
+
+        /* Highlight box */
+        .highlight-box {
+            background: linear-gradient(135deg, rgba(0, 255, 136, 0.1), rgba(0, 212, 255, 0.1));
+            border: 1px solid rgba(0, 255, 136, 0.2);
+            border-radius: 12px;
+            padding: 1.5rem 2rem;
+            margin: 2rem 0;
+        }
+
+        .highlight-box p {
+            font-size: 1.1rem;
+            color: var(--text-primary);
+        }
+
+        /* Emoji flag */
+        .flag {
+            font-size: 1.5rem;
+            margin-right: 0.5rem;
+        }
+    </style>
+    <script src="https://openpanel.dev/op1.js" defer async></script>
+    <script>
+      window.op = window.op || function(...args) { (window.op.q = window.op.q || []).push(args); };
+      window.op('init', {
+        clientId: '80920d68-b57d-4c7b-baf6-3518495a3739',
+        apiUrl: 'https://counter.hackrsvalv.com/api',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
+</head>
+<body>
+    <div class="progress" id="progress"></div>
+    
+    <nav class="nav">
+        <button class="nav-dot active" data-slide="0"></button>
+        <button class="nav-dot" data-slide="1"></button>
+        <button class="nav-dot" data-slide="2"></button>
+        <button class="nav-dot" data-slide="3"></button>
+        <button class="nav-dot" data-slide="4"></button>
+        <button class="nav-dot" data-slide="5"></button>
+        <button class="nav-dot" data-slide="6"></button>
+        <button class="nav-dot" data-slide="7"></button>
+        <button class="nav-dot" data-slide="8"></button>
+    </nav>
+
+    <div class="slide-counter">
+        <span id="current">01</span> / <span id="total">08</span>
+    </div>
+
+    <!-- Slide 1: Title -->
+    <section class="slide slide-1" id="slide-0">
+        <div class="grid-overlay"></div>
+        <div class="content">
+            <span class="tag">wgmesh + BGP Anycast</span>
+            <h1>Global CDN<br>Zero Infrastructure</h1>
+            <p class="subtitle">Build a worldwide content delivery network using WireGuard mesh and anycast routing. No central servers required.</p>
+            
+            <div class="card-grid" style="margin-top: 4rem;">
+                <div class="card">
+                    <div class="card-icon">🌍</div>
+                    <h4>Global Reach</h4>
+                    <p>Users automatically route to nearest edge via BGP anycast</p>
+                </div>
+                <div class="card">
+                    <div class="card-icon">🔐</div>
+                    <h4>Fully Encrypted</h4>
+                    <p>WireGuard mesh encrypts all internal traffic</p>
+                </div>
+                <div class="card">
+                    <div class="card-icon">🏠</div>
+                    <h4>Hidden Origins</h4>
+                    <p>Backend servers can be anywhere—even your home</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Slide: Get wgmesh -->
+    <section class="slide slide-2" id="get-wgmesh">
+        <div class="grid-overlay"></div>
+        <div class="content">
+            <span class="tag">Get Started</span>
+            <h2 style="background: linear-gradient(135deg, var(--green), var(--blue)); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">Connect Anything, Anywhere</h2>
+            <p style="color: var(--text-muted); font-size: 1.1rem; margin: 1rem 0 2rem;">
+                Share a secret. Join the mesh. That's it.<br>
+                No coordination server. No manual key exchange. Works behind NAT.
+            </p>
+
+            <div class="highlight-box" style="margin-bottom: 2.5rem;">
+                <div class="code-block" style="font-size: 0.95rem;">
+                    <span class="comment"># macOS</span><br>
+                    brew install atvirokodosprendimai/tap/wgmesh<br><br>
+                    <span class="comment"># Go</span><br>
+                    go install github.com/atvirokodosprendimai/wgmesh@latest<br><br>
+                    <span class="comment"># Docker</span><br>
+                    docker pull ghcr.io/atvirokodosprendimai/wgmesh
+                </div>
+            </div>
+
+            <div class="card-grid">
+                <div class="card">
+                    <div class="card-icon">🏠</div>
+                    <h4>Homelab Mesh</h4>
+                    <p>Link your NAS, Pi, and cloud VPS into one encrypted network. Works behind any NAT.</p>
+                </div>
+                <div class="card">
+                    <div class="card-icon">🌍</div>
+                    <h4>Multi-Site LAN</h4>
+                    <p>Connect offices, data centers, and edge nodes. DHT discovery finds peers automatically.</p>
+                </div>
+                <div class="card">
+                    <div class="card-icon">🔑</div>
+                    <h4>Remote Access</h4>
+                    <p>Access any device on the mesh from anywhere. No port forwarding, no dynamic DNS.</p>
+                </div>
+            </div>
+
+            <p style="text-align: center; margin-top: 2.5rem;">
+                <a href="https://github.com/atvirokodosprendimai/wgmesh#quick-start" style="color: var(--green); text-decoration: none; font-size: 1.1rem; font-weight: 600;">
+                    Read the quickstart guide &rarr;
+                </a>
+            </p>
+        </div>
+    </section>
+
+    <!-- Slide 2: The Problem -->
+    <section class="slide slide-2" id="slide-1">
+        <div class="grid-overlay"></div>
+        <div class="content">
+            <span class="tag">The Challenge</span>
+            <h2>Traditional CDN = Vendor Lock-in</h2>
+            
+            <div class="two-legs" style="margin-top: 3rem;">
+                <div class="card">
+                    <h4 style="color: var(--red);">❌ Traditional CDN</h4>
+                    <ul class="bullet-list">
+                        <li><strong>Cloudflare/AWS</strong> controls your traffic</li>
+                        <li><strong>Pay per GB</strong> — costs scale linearly</li>
+                        <li><strong>Vendor lock-in</strong> — hard to migrate</li>
+                        <li><strong>No self-hosting</strong> — origins must be public</li>
+                        <li><strong>Compliance risk</strong> — data through 3rd party</li>
+                    </ul>
+                </div>
+                <div class="card">
+                    <h4 style="color: var(--green);">✅ wgmesh CDN</h4>
+                    <ul class="bullet-list">
+                        <li><strong>You own everything</strong> — full control</li>
+                        <li><strong>Fixed cost</strong> — ~$5/mo per edge PoP</li>
+                        <li><strong>Portable</strong> — works on any VPS</li>
+                        <li><strong>Origins anywhere</strong> — home server OK</li>
+                        <li><strong>Your network</strong> — data stays private</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Slide 3: Architecture Overview -->
+    <section class="slide slide-3" id="slide-2">
+        <div class="grid-overlay"></div>
+        <div class="content">
+            <span class="tag">Architecture</span>
+            <h2>How It Works</h2>
+            
+            <div class="network-diagram">
+                <div class="diagram-row">
+                    <div class="diagram-node dns">
+                        <div class="diagram-node-label">DNS</div>
+                        <div class="diagram-node-title">www.delfi.lt → 2001:db8::1</div>
+                    </div>
+                </div>
+                
+                <div class="diagram-arrow">↓ same IP for everyone</div>
+                
+                <div class="diagram-row">
+                    <div class="diagram-node user">
+                        <div class="diagram-node-label">🇺🇸 US</div>
+                        <div class="diagram-node-title">User</div>
+                    </div>
+                    <div class="diagram-node user">
+                        <div class="diagram-node-label">🇪🇺 EU</div>
+                        <div class="diagram-node-title">User</div>
+                    </div>
+                    <div class="diagram-node user">
+                        <div class="diagram-node-label">🇯🇵 Asia</div>
+                        <div class="diagram-node-title">User</div>
+                    </div>
+                </div>
+                
+                <div class="diagram-arrow">↓ BGP routes to nearest</div>
+                
+                <div class="diagram-row">
+                    <div class="diagram-node edge">
+                        <div class="diagram-node-label">Vultr LA</div>
+                        <div class="diagram-node-title">Edge PoP</div>
+                    </div>
+                    <div class="diagram-node edge">
+                        <div class="diagram-node-label">Hetzner DE</div>
+                        <div class="diagram-node-title">Edge PoP</div>
+                    </div>
+                    <div class="diagram-node edge">
+                        <div class="diagram-node-label">Vultr Tokyo</div>
+                        <div class="diagram-node-title">Edge PoP</div>
+                    </div>
+                </div>
+                
+                <div class="diagram-arrow">↓ encrypted tunnel</div>
+                
+                <div class="diagram-row">
+                    <div class="diagram-node mesh">
+                        <div class="diagram-node-label">wgmesh</div>
+                        <div class="diagram-node-title">🔐 WireGuard Full Mesh (10.77.0.0/16)</div>
+                    </div>
+                </div>
+                
+                <div class="diagram-arrow">↓ routes to internal IP</div>
+                
+                <div class="diagram-row">
+                    <div class="diagram-node origin">
+                        <div class="diagram-node-label">🏠 Japan</div>
+                        <div class="diagram-node-title">WordPress</div>
+                    </div>
+                    <div class="diagram-node origin">
+                        <div class="diagram-node-label">🇱🇹 Lithuania</div>
+                        <div class="diagram-node-title">API</div>
+                    </div>
+                    <div class="diagram-node origin">
+                        <div class="diagram-node-label">☁️ B2</div>
+                        <div class="diagram-node-title">Media</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Slide 4: Two Legs -->
+    <section class="slide slide-1" id="slide-3">
+        <div class="grid-overlay"></div>
+        <div class="content">
+            <span class="tag">Edge Node Design</span>
+            <h2>The "Two Legs" Pattern</h2>
+            <p class="subtitle">Each edge server has two network interfaces: one public (anycast), one private (mesh).</p>
+            
+            <div class="two-legs">
+                <div class="leg public">
+                    <h4>
+                        <div class="leg-icon">🌐</div>
+                        Public Leg (eth0)
+                    </h4>
+                    <div class="code-block">
+                        <span class="comment"># Anycast IP - same on ALL edge nodes</span><br>
+                        eth0: <span class="string">2001:db8:any::1</span><br><br>
+                        <span class="comment"># BGP announces to upstream</span><br>
+                        <span class="keyword">neighbor</span> vultr <span class="keyword">announce</span> 2001:db8::/48<br><br>
+                        <span class="comment"># nginx terminates TLS here</span><br>
+                        listen <span class="number">443</span> ssl;
+                    </div>
+                    <p style="color: var(--text-muted); margin-top: 1rem;">Users connect here. BGP magic routes them to the nearest edge.</p>
+                </div>
+                <div class="leg mesh">
+                    <h4>
+                        <div class="leg-icon">🔐</div>
+                        Mesh Leg (wg0)
+                    </h4>
+                    <div class="code-block">
+                        <span class="comment"># Unique mesh IP per node</span><br>
+                        wg0: <span class="string">10.77.0.10</span>/16<br><br>
+                        <span class="comment"># Auto-joins mesh with secret</span><br>
+                        wgmesh join --secret <span class="string">'cdn-2025'</span><br><br>
+                        <span class="comment"># Backend routing</span><br>
+                        proxy_pass http://<span class="string">10.77.1.50</span>;
+                    </div>
+                    <p style="color: var(--text-muted); margin-top: 1rem;">Internal traffic flows through encrypted WireGuard mesh.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Slide 5: BGP Anycast Explained -->
+    <section class="slide slide-2" id="slide-4">
+        <div class="grid-overlay"></div>
+        <div class="content">
+            <span class="tag">BGP Anycast</span>
+            <h2>How Same IP Works Everywhere</h2>
+            
+            <div class="highlight-box">
+                <p>💡 <strong>Anycast</strong> = Multiple servers announce the same IP prefix. Internet routers automatically send traffic to the <em>nearest</em> announcer.</p>
+            </div>
+            
+            <div class="architecture">
+                <div class="arch-layer">
+                    <div class="arch-label">🇺🇸 US User</div>
+                    <div class="arch-content">
+                        <div class="arch-node">Requests 2001:db8::1</div>
+                        <div class="arch-node">→</div>
+                        <div class="arch-node">US ISP sees route via Vultr LA (2 hops)</div>
+                        <div class="arch-node">→</div>
+                        <div class="arch-node highlight">US Edge</div>
+                    </div>
+                </div>
+                <div class="arch-layer">
+                    <div class="arch-label">🇪🇺 EU User</div>
+                    <div class="arch-content">
+                        <div class="arch-node">Requests 2001:db8::1</div>
+                        <div class="arch-node">→</div>
+                        <div class="arch-node">EU ISP sees route via Hetzner (1 hop)</div>
+                        <div class="arch-node">→</div>
+                        <div class="arch-node highlight">EU Edge</div>
+                    </div>
+                </div>
+                <div class="arch-layer">
+                    <div class="arch-label">🇯🇵 Asia User</div>
+                    <div class="arch-content">
+                        <div class="arch-node">Requests 2001:db8::1</div>
+                        <div class="arch-node">→</div>
+                        <div class="arch-node">Asia ISP sees route via Vultr Tokyo (2 hops)</div>
+                        <div class="arch-node">→</div>
+                        <div class="arch-node highlight">Asia Edge</div>
+                    </div>
+                </div>
+            </div>
+            
+            <p style="color: var(--text-muted); text-align: center; margin-top: 2rem;">
+                No GeoDNS needed. No latency from DNS resolution. Pure routing magic.
+            </p>
+        </div>
+    </section>
+
+    <!-- Slide 6: How to Get BYOIP -->
+    <section class="slide slide-3" id="slide-5">
+        <div class="grid-overlay"></div>
+        <div class="content">
+            <span class="tag">Getting Started</span>
+            <h2>How to Get Your Own IP Prefix</h2>
+            
+            <table class="comparison-table">
+                <thead>
+                    <tr>
+                        <th>Option</th>
+                        <th>Difficulty</th>
+                        <th>Cost</th>
+                        <th>Time</th>
+                        <th>Notes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><strong>Vultr BGP</strong></td>
+                        <td><span class="badge badge-green">Easy</span></td>
+                        <td>$0 extra</td>
+                        <td>24-48h</td>
+                        <td>Request via support ticket, they allocate /48</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Path.net</strong></td>
+                        <td><span class="badge badge-green">Easy</span></td>
+                        <td>~$20/mo/PoP</td>
+                        <td>Instant</td>
+                        <td>Built for anycast, prefix included</td>
+                    </tr>
+                    <tr>
+                        <td><strong>BuyVM</strong></td>
+                        <td><span class="badge badge-green">Easy</span></td>
+                        <td>~$3.50/mo</td>
+                        <td>24h</td>
+                        <td>Budget option with BGP, request prefix</td>
+                    </tr>
+                    <tr>
+                        <td><strong>RIPE LIR</strong></td>
+                        <td><span class="badge badge-orange">Hard</span></td>
+                        <td>€1400/yr</td>
+                        <td>Weeks</td>
+                        <td>Own your prefix forever, more paperwork</td>
+                    </tr>
+                    <tr>
+                        <td><strong>GeoDNS (No BGP)</strong></td>
+                        <td><span class="badge badge-blue">Easiest</span></td>
+                        <td>Free</td>
+                        <td>Instant</td>
+                        <td>Cloudflare DNS geo-steering, no anycast</td>
+                    </tr>
+                </tbody>
+            </table>
+            
+            <div class="highlight-box">
+                <p>🚀 <strong>Recommended:</strong> Start with GeoDNS (free), same wgmesh backbone. Add true anycast later when you have a prefix.</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Slide 7: Quick Start -->
+    <section class="slide slide-1" id="slide-6">
+        <div class="grid-overlay"></div>
+        <div class="content">
+            <span class="tag">Quick Start</span>
+            <h2>Deploy in 5 Minutes</h2>
+            
+            <div class="card-grid">
+                <div class="card">
+                    <h4>1. Spin up edge VPS</h4>
+                    <div class="code-block">
+                        <span class="comment"># Vultr, Hetzner, or any VPS</span><br>
+                        <span class="comment"># One in each region you want</span><br>
+                        US: Vultr Los Angeles<br>
+                        EU: Hetzner Falkenstein<br>
+                        Asia: Vultr Tokyo
+                    </div>
+                </div>
+                <div class="card">
+                    <h4>2. Join the mesh</h4>
+                    <div class="code-block">
+                        <span class="comment"># Same command on each edge</span><br>
+                        wgmesh join \<br>
+                        &nbsp;&nbsp;--secret <span class="string">'my-cdn-secret-2025'</span>
+                    </div>
+                </div>
+                <div class="card">
+                    <h4>3. Configure nginx</h4>
+                    <div class="code-block">
+                        <span class="keyword">upstream</span> backend {<br>
+                        &nbsp;&nbsp;server <span class="string">10.77.1.50</span>:<span class="number">80</span>;<br>
+                        }<br><br>
+                        <span class="keyword">server</span> {<br>
+                        &nbsp;&nbsp;listen <span class="number">443</span> ssl;<br>
+                        &nbsp;&nbsp;proxy_pass http://backend;<br>
+                        }
+                    </div>
+                </div>
+                <div class="card">
+                    <h4>4. Join origin to mesh</h4>
+                    <div class="code-block">
+                        <span class="comment"># On your home server / origin</span><br>
+                        wgmesh join \<br>
+                        &nbsp;&nbsp;--secret <span class="string">'my-cdn-secret-2025'</span><br><br>
+                        <span class="comment"># Gets mesh IP 10.77.1.50</span><br>
+                        <span class="comment"># Now reachable from all edges!</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Slide 8: Summary -->
+    <section class="slide slide-2" id="slide-7">
+        <div class="grid-overlay"></div>
+        <div class="content">
+            <span class="tag">Summary</span>
+            <h2>Your Own Global CDN</h2>
+            
+            <div class="card-grid" style="margin-bottom: 3rem;">
+                <div class="card">
+                    <div class="card-icon">💰</div>
+                    <h4>~$15-20/mo Total</h4>
+                    <p>3x $5 VPS for global coverage. Origins can be free (home server).</p>
+                </div>
+                <div class="card">
+                    <div class="card-icon">⚡</div>
+                    <h4>5 Minute Setup</h4>
+                    <p>One command per node. Auto-discovery handles the rest.</p>
+                </div>
+                <div class="card">
+                    <div class="card-icon">🔒</div>
+                    <h4>End-to-End Encrypted</h4>
+                    <p>TLS to edge, WireGuard to origin. No cleartext ever.</p>
+                </div>
+                <div class="card">
+                    <div class="card-icon">🏠</div>
+                    <h4>Origin Anywhere</h4>
+                    <p>Home server, Raspberry Pi, or any cloud. Behind NAT = OK.</p>
+                </div>
+            </div>
+            
+            <div class="highlight-box" style="text-align: center;">
+                <p style="font-size: 1.5rem; margin-bottom: 1rem;">
+                    <strong>wgmesh join --secret 'your-secret'</strong>
+                </p>
+                <p style="color: var(--text-muted);">
+                    That's it. Same command everywhere. Mesh forms automatically.
+                </p>
+            </div>
+            
+            <p style="text-align: center; margin-top: 3rem; color: var(--text-muted);">
+                <a href="https://github.com/atvirokodosprendimai/wgmesh" style="color: var(--green); text-decoration: none;">
+                    github.com/atvirokodosprendimai/wgmesh →
+                </a>
+            </p>
+        </div>
+    </section>
+
+    <script>
+        // Navigation
+        const slides = document.querySelectorAll('.slide');
+        const navDots = document.querySelectorAll('.nav-dot');
+        const progress = document.getElementById('progress');
+        const currentSlide = document.getElementById('current');
+        const totalSlides = document.getElementById('total');
+
+        totalSlides.textContent = String(slides.length).padStart(2, '0');
+
+        // Update on scroll
+        function updateNav() {
+            const scrollPos = window.scrollY;
+            const windowHeight = window.innerHeight;
+            
+            slides.forEach((slide, index) => {
+                const slideTop = slide.offsetTop;
+                const slideBottom = slideTop + slide.offsetHeight;
+                
+                if (scrollPos >= slideTop - windowHeight/2 && scrollPos < slideBottom - windowHeight/2) {
+                    navDots.forEach(dot => dot.classList.remove('active'));
+                    navDots[index].classList.add('active');
+                    currentSlide.textContent = String(index + 1).padStart(2, '0');
+                }
+            });
+
+            // Progress bar
+            const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+            const scrollPercent = (scrollPos / docHeight) * 100;
+            progress.style.width = scrollPercent + '%';
+        }
+
+        window.addEventListener('scroll', updateNav);
+
+        // Click navigation
+        navDots.forEach(dot => {
+            dot.addEventListener('click', () => {
+                const slideIndex = parseInt(dot.dataset.slide);
+                slides[slideIndex].scrollIntoView({ behavior: 'smooth' });
+            });
+        });
+
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            const currentIndex = Array.from(navDots).findIndex(dot => dot.classList.contains('active'));
+            
+            if (e.key === 'ArrowDown' || e.key === 'ArrowRight' || e.key === ' ') {
+                e.preventDefault();
+                if (currentIndex < slides.length - 1) {
+                    slides[currentIndex + 1].scrollIntoView({ behavior: 'smooth' });
+                }
+            }
+            
+            if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+                e.preventDefault();
+                if (currentIndex > 0) {
+                    slides[currentIndex - 1].scrollIntoView({ behavior: 'smooth' });
+                }
+            }
+        });
+
+        // Initial state
+        updateNav();
+    </script>
+</body>
+</html>

--- a/testlab/cloud/provision.sh
+++ b/testlab/cloud/provision.sh
@@ -287,6 +287,11 @@ _setup_single_vm() {
     # netlink/RTNL — the symptom from Hetzner run 25609234757).
     if [ "${WGMESH_COROOT:-0}" = "1" ]; then
         local coroot_endpoint="${WGMESH_COROOT_COLLECTOR:-https://table.beerpub.dev}"
+        local coroot_api_key="${WGMESH_COROOT_API_KEY:-${COROOT_API_TOKEN:-}}"
+        if [ -z "$coroot_api_key" ]; then
+            log_error "VM $node coroot enabled but COROOT_API_TOKEN/WGMESH_COROOT_API_KEY is empty — agent would be silently 401'd at ingestion. Pass the secret through to the test step env."
+            return 1
+        fi
         # Default to nycterent's fork — that's where PR coroot/coroot-node-agent#301
         # `fix-l7-memory-oom` lives. Upstream `coroot/coroot-node-agent` does NOT
         # have this branch (verified 2026-05-10 via gh pr view 301 — headRepositoryOwner
@@ -324,7 +329,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/opt/coroot/coroot-node-agent --collector-endpoint=${coroot_endpoint} --cgroupfs-root=/sys/fs/cgroup
+ExecStart=/opt/coroot/coroot-node-agent --collector-endpoint=${coroot_endpoint} --api-key=${coroot_api_key} --cgroupfs-root=/sys/fs/cgroup
 Restart=on-failure
 LimitNOFILE=65535
 MemoryHigh=2G


### PR DESCRIPTION
Coroot Community 1.19.7 collector requires `X-API-Key` header on ingestion (verified in coroot/coroot/api/auth.go:114 + collector/types.go:22). `coroot-node-agent` exposes `--api-key` flag for exactly this. Prior install passed no key → all OTLP pushes silently 401-rejected → 'no nodes registered'.

Wires `COROOT_API_TOKEN` through workflow → env → provision.sh → agent ExecStart. Hard-fails if token is empty rather than installing a broken agent.

Founder's earlier correction "COROOT_API_TOKEN is the way" — correct for INGESTION, not UI. Two different auth surfaces. This fixes the ingestion side.