### PR TITLE
fix(bot): raise PR_MAX_LINES default 500→3000

### DIFF
--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Configuration (all overridable via environment)
 # ---------------------------------------------------------------------------
-PR_MAX_LINES="${PR_MAX_LINES:-500}"
+PR_MAX_LINES="${PR_MAX_LINES:-3000}"
 MAX_RETRY_COUNT="${MAX_RETRY_COUNT:-3}"
 APPROVED_AUTHORS="${APPROVED_AUTHORS:-copilot-swe-agent[bot],goose[bot]}"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"


### PR DESCRIPTION
500 blocked legitimate large PRs (e.g. #570 e2e framework at 2658 lines). A human can't review what the bot won't merge — the guardrail was circular. 3000 still catches runaway Goose diffs while allowing real test infra to ship.