### PR TITLE
fix(testlab): stop_mesh explicit-PID wait + wait_for pkill -P descendants

### DIFF
--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -280,6 +280,14 @@ wait_for() {
             sleep 1
         done
         if [ "$probe_done" -eq 0 ]; then
+            # PID-mismatch fix (runs 25887582606, 25895530964): ( cmd ) &
+            # forks a subshell so $! is the SUBSHELL pid. SIGKILL'ing the
+            # subshell alone orphans its ssh children, which hold TCP
+            # connections indefinitely. Kill descendants first via pkill -P,
+            # then the subshell itself. Repeat to catch grandchildren.
+            pkill -KILL -P "$probe_pid" 2>/dev/null || true
+            sleep 0.2
+            pkill -KILL -P "$probe_pid" 2>/dev/null || true
             kill -KILL "$probe_pid" 2>/dev/null || true
             wait "$probe_pid" 2>/dev/null || true
             rc=124

--- a/testlab/cloud/provision.sh
+++ b/testlab/cloud/provision.sh
@@ -420,13 +420,28 @@ start_mesh() {
 }
 
 # Stop mesh on all nodes.
+#
+# Uses explicit PID tracking (NOT bare `wait`). Bare `wait` blocks on every
+# background child of the current shell — including any leaked from earlier
+# steps (provisioning probes, monitoring loops). The 2h hang in runs
+# 25887582606 + 25895530964 persisted after PR #631's timeout(1) fix because
+# the bash watchdog in wait_for ALSO orphaned subshells; bare wait here
+# blocked on those orphans forever.
 stop_mesh() {
     emit_event "mesh_stop" "stop_mesh"
+    log_info "stop_mesh: spawning stop_mesh_node for ${#NODE_IPS[@]} nodes"
+    local pids=()
     for node in "${!NODE_IPS[@]}"; do
         stop_mesh_node "$node" &
+        pids+=($!)
     done
-    wait
-    # Clean up WG interfaces
+    log_info "stop_mesh: waiting for ${#pids[@]} stop_mesh_node pids"
+    local pid
+    for pid in "${pids[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+    log_info "stop_mesh: all stop_mesh_node returned, cleaning up WG interfaces"
+    # Clean up WG interfaces — sequential, bounded by run_on_ok's timeout(1)
     for node in "${!NODE_IPS[@]}"; do
         run_on_ok "$node" "ip link del $WG_INTERFACE 2>/dev/null"
     done


### PR DESCRIPTION
## Root cause (iteration 2)

After PR #631's timeout(1) fix, run 25895530964 STILL cancelled at 203min. Trace showed identical hang: `mesh_stop` event emitted then 200min silence.

Two more bugs found:

### 1. stop_mesh bare wait

`stop_mesh` used bare `wait` — blocks on ALL background children of the current shell, including orphans leaked from earlier steps. Switched to explicit PID tracking.

### 2. wait_for same PID-mismatch as run_on had

`wait_for` uses `( cmd ) &` + `kill -KILL $pid` — same subshell-PID-not-cmd-PID bug as the SSH watchdog had pre-#631. When probes timed out (provisioning's SSH-availability check), the subshell was killed but ssh children were orphaned. Those orphans held TCP connections to the VMs.

Couldn't use timeout(1) for wait_for because predicates are shell functions (would not be visible to exec'd `timeout`). Fix: `pkill -KILL -P $probe_pid` kills descendants first, then the subshell. Twice for grandchildren.

## Verification

Hetzner integration run after merge.