### PR TITLE
fix(ci): bump Hetzner tier timeout 180→240 min

### DIFF
--- a/.github/workflows/hetzner-integration.yml
+++ b/.github/workflows/hetzner-integration.yml
@@ -96,7 +96,7 @@ jobs:
     name: "Tier ${{ matrix.tier }}"
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 180
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Tier 6 needs more wall-clock. Run 25910274587 got 2 of 11 tests done in 180min. Bump to 240. See #634 for trim-overhead followup.