### PR TITLE
fix(testlab): t30 simultaneous_restart explicit PID wait (kills 4h Tier 6 hang)

### DIFF
--- a/testlab/cloud/test-cloud.sh
+++ b/testlab/cloud/test-cloud.sh
@@ -1045,11 +1045,20 @@ test_t31_rolling_restart() {
 test_t32_simultaneous_restart() {
     _chaos_setup
 
-    # Restart all nodes at once
+    # Restart all nodes at once. Use explicit PID tracking (NOT bare `wait`)
+    # because bare wait blocks on every background child of the shell —
+    # same hang pattern that bit stop_mesh (fixed in PR #632). Run
+    # 25919050735 hit this exact bug: trace stopped at chaos_setup_end of
+    # T30 and the shell hung for 229 minutes inside this wait.
+    local pids=()
     for node in "${!NODE_IPS[@]}"; do
         restart_mesh_node "$node" &
+        pids+=($!)
     done
-    wait
+    local pid
+    for pid in "${pids[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
 
     sleep 10
     verify_full_mesh 90


### PR DESCRIPTION
Run 25919050735 hung 229 minutes inside test_t30's bare `wait` — same bug pattern as stop_mesh had before #632. Trace stopped at chaos_setup_end of T30 'Simultaneous restart'. Fix: explicit PID tracking like stop_mesh.

This was the last bare `wait` after parallel `& ` spawn in test-cloud.sh.