### PR TITLE
feat(testlab): mid-run progress heartbeat for Hetzner CI

### DIFF
--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -890,12 +890,16 @@ run_test() {
     local id="$1" name="$2" func="$3"; shift 3
     local total="${TOTAL_TESTS_IN_TIER:-?}"
     local seq=$(( TESTS_PASSED + TESTS_FAILED + TESTS_SKIPPED + 1 ))
+    CURRENT_TEST_ID="$id"
+    CURRENT_TEST_START_EPOCH=$(date +%s)
+    echo "::group::Test $id - $name"
+    echo "::notice title=$id started::$name"
 
     echo ""
     log_test "=== [$seq/$total] $id: $name ==="
 
     local start rc tmpfile
-    start=$(date +%s)
+    start="$CURRENT_TEST_START_EPOCH"
     tmpfile=$(mktemp)
     emit_event "test_start" "$id" "name=$name"
 
@@ -906,7 +910,8 @@ run_test() {
     set +e
     "$func" "$@" > >(tee "$tmpfile") 2>&1
     rc=$?
-    wait  # ensure tee flushes before we read tmpfile
+    local tee_pid=$!
+    wait "$tee_pid" 2>/dev/null || true  # ensure tee flushes before we read tmpfile
     set -e
 
     local output
@@ -934,6 +939,10 @@ run_test() {
     # Record timing for Gantt chart
     TEST_TIMING_EVENTS+=("${CURRENT_TIER:-0}|${id}|${name}|${start}|${end_epoch}|${result}")
     emit_event "test_end" "$id" "name=$name" "result=$result" "duration=$duration"
+    echo "::notice title=$id $result::duration=${duration}s"
+    echo "::endgroup::"
+    CURRENT_TEST_ID=""
+    CURRENT_TEST_START_EPOCH=""
 
     # Running tally after each test
     log_test "  Progress: ${GREEN}${TESTS_PASSED} passed${NC}, ${RED}${TESTS_FAILED} failed${NC}, ${YELLOW}${TESTS_SKIPPED} skipped${NC} of $total"

--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -385,22 +385,69 @@ mesh_ping_soak() {
     local from="$1" to="$2" dur="${3:-300}" max_loss="${4:-5}"
     local to_ip="${NODE_MESH_IPS[$to]}"
     log_info "soak: ping $from -> $to ($to_ip) for ${dur}s, max ${max_loss}% loss"
-    local out
-    out=$(RUN_ON_TIMEOUT_SEC=$((dur + 30)) run_on "$from" "ping -i 1 -w $dur -q $to_ip 2>&1 || true")
+    local snapshot="${LOG_DIR}/soak-current.txt"
+    local snapshot_tmp="${snapshot}.tmp"
+    rm -f "$snapshot" "$snapshot_tmp"
+
+    local out="" transmitted=0 received=0 elapsed=0
+    while [ "$elapsed" -lt "$dur" ]; do
+        local remaining=$(( dur - elapsed ))
+        local count=10
+        [ "$remaining" -lt "$count" ] && count="$remaining"
+        [ "$count" -lt 1 ] && count=1
+
+        local chunk_out
+        chunk_out=$(RUN_ON_TIMEOUT_SEC=$((count + 30)) run_on "$from" "ping -i 1 -w $count -W 2 -q $to_ip 2>&1 || true")
+        out="${out}${chunk_out}"$'\n'
+
+        local chunk_transmitted chunk_received
+        chunk_transmitted=$(echo "$chunk_out" | awk '/packets transmitted/ {print $1; exit}' || true)
+        chunk_received=$(echo "$chunk_out" | awk -F',' '/packets transmitted/ {gsub(/^[[:space:]]+/, "", $2); print $2 + 0; exit}' || true)
+        transmitted=$(( transmitted + ${chunk_transmitted:-0} ))
+        received=$(( received + ${chunk_received:-0} ))
+        elapsed=$(( elapsed + count ))
+
+        local loss_now updated_at
+        loss_now=$(awk -v tx="$transmitted" -v rx="$received" 'BEGIN {
+            if (tx <= 0) { print "100"; exit }
+            printf "%.1f", ((tx - rx) * 100) / tx
+        }')
+        updated_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        {
+            echo "state=in_flight"
+            echo "from=$from"
+            echo "to=$to"
+            echo "to_ip=$to_ip"
+            echo "elapsed_sec=$elapsed"
+            echo "duration_sec=$dur"
+            echo "received=$received"
+            echo "transmitted=$transmitted"
+            echo "loss_pct=$loss_now"
+            echo "updated_at=$updated_at"
+        } > "$snapshot_tmp"
+        mv "$snapshot_tmp" "$snapshot"
+    done
+
     echo "$out"
     local loss
-    loss=$(echo "$out" | grep -oE '[0-9]+(\.[0-9]+)?% packet loss' | head -1 | grep -oE '^[0-9]+(\.[0-9]+)?' || true)
+    loss=$(awk -v tx="$transmitted" -v rx="$received" 'BEGIN {
+        if (tx <= 0) { exit 1 }
+        printf "%.1f", ((tx - rx) * 100) / tx
+    }' || true)
     if [ -z "$loss" ]; then
         log_error "soak: could not parse packet loss from ping output"
+        rm -f "$snapshot" "$snapshot_tmp"
         return 1
     fi
     local loss_int
     loss_int=$(awk -v l="$loss" 'BEGIN { printf "%d", l + 0.999 }')
     if [ "$loss_int" -gt "$max_loss" ]; then
         log_error "soak: $from -> $to loss ${loss}% exceeds ${max_loss}%"
+        rm -f "$snapshot" "$snapshot_tmp"
         return 1
     fi
     log_info "soak: $from -> $to loss ${loss}% (under ${max_loss}%) OK"
+    rm -f "$snapshot" "$snapshot_tmp"
     return 0
 }
 

--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -45,6 +45,9 @@ declare -a TEST_RESULTS=()
 TESTS_PASSED=0
 TESTS_FAILED=0
 TESTS_SKIPPED=0
+HEARTBEAT_PID=""
+CURRENT_TEST_ID=""
+CURRENT_TEST_START_EPOCH=""
 
 # Observability: timing + tracing
 CURRENT_TIER=""
@@ -959,6 +962,153 @@ print_summary() {
     echo "------------------------------------------------------------------------------------------------------------"
     echo -e "Total: ${GREEN}${TESTS_PASSED} passed${NC}, ${RED}${TESTS_FAILED} failed${NC}, ${YELLOW}${TESTS_SKIPPED} skipped${NC}"
     echo ""
+}
+
+# Emit a live progress view for long-running GitHub Actions tier jobs.
+_progress_heartbeat() {
+    local tier="$1"
+    while true; do
+        local out="${GITHUB_STEP_SUMMARY:-${LOG_DIR}/heartbeat-status.md}"
+        local tmp="${out}.tmp"
+        local now elapsed=0 current_test="${CURRENT_TEST_ID:-}"
+        local current_start="${CURRENT_TEST_START_EPOCH:-}"
+        local passed="$TESTS_PASSED" failed="$TESTS_FAILED" skipped="$TESTS_SKIPPED"
+        now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        if [ -f "$TRACE_FILE" ]; then
+            local trace_state
+            trace_state=$(awk '
+                function json_value(line, key, pattern, raw) {
+                    pattern = "\"" key "\":\"[^\"]*\""
+                    if (match(line, pattern)) {
+                        raw = substr(line, RSTART + length(key) + 4, RLENGTH - length(key) - 4)
+                        return raw
+                    }
+                    pattern = "\"" key "\":[^,}]*"
+                    if (match(line, pattern)) {
+                        raw = substr(line, RSTART + length(key) + 3, RLENGTH - length(key) - 3)
+                        return raw
+                    }
+                    return ""
+                }
+                {
+                    type = json_value($0, "type")
+                    name = json_value($0, "name")
+                    result = json_value($0, "result")
+                    ts = int(json_value($0, "ts"))
+                    if (type == "test_start") {
+                        current = name
+                        start = ts
+                    } else if (type == "test_end") {
+                        if (result == "PASS") {
+                            pass++
+                        } else if (result == "FAIL") {
+                            fail++
+                        } else if (result == "SKIP") {
+                            skip++
+                        }
+                        if (name == current) {
+                            current = ""
+                            start = ""
+                        }
+                    }
+                }
+                END {
+                    printf "%s|%s|%d|%d|%d\n", current, start, pass, fail, skip
+                }
+            ' "$TRACE_FILE" || true)
+            IFS='|' read -r current_test current_start passed failed skipped <<< "$trace_state"
+        fi
+        if [ -n "$current_start" ]; then
+            elapsed=$(( $(date +%s) - current_start ))
+        fi
+
+        mkdir -p "$(dirname "$out")" || true
+        {
+            echo "## wgmesh Live Progress"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Tier | $tier |"
+            echo "| Current test | ${current_test:-none} |"
+            echo "| Current test elapsed | ${elapsed}s |"
+            echo "| Updated at | $now |"
+            echo "| Results | ${passed} passed, ${failed} failed, ${skipped} skipped |"
+            echo ""
+
+            if [ -n "$current_test" ] && [ -f "${LOG_DIR}/soak-current.txt" ]; then
+                echo "### In-Flight Soak"
+                echo ""
+                echo '```text'
+                cat "${LOG_DIR}/soak-current.txt" || true
+                echo '```'
+                echo ""
+            fi
+
+            echo "### Recent Trace Events"
+            echo ""
+            echo "| timestamp | event | detail |"
+            echo "|---|---|---|"
+            tail -30 "$TRACE_FILE" 2>/dev/null | awk '
+                function json_value(line, key, pattern, raw) {
+                    pattern = "\"" key "\":\"[^\"]*\""
+                    if (match(line, pattern)) {
+                        raw = substr(line, RSTART + length(key) + 4, RLENGTH - length(key) - 4)
+                        gsub(/\|/, "\\|", raw)
+                        return raw
+                    }
+                    pattern = "\"" key "\":[^,}]*"
+                    if (match(line, pattern)) {
+                        raw = substr(line, RSTART + length(key) + 3, RLENGTH - length(key) - 3)
+                        gsub(/\|/, "\\|", raw)
+                        return raw
+                    }
+                    return ""
+                }
+                {
+                    ts = json_value($0, "ts")
+                    event = json_value($0, "type")
+                    name = json_value($0, "name")
+                    detail = name
+                    if (detail == "") {
+                        detail = $0
+                    }
+                    gsub(/\|/, "\\|", detail)
+                    printf "| %s | %s | %s |\n", ts, event, detail
+                }
+            ' || true
+            echo ""
+
+            echo "### VM Log Tails"
+            echo ""
+            local log_file node
+            for log_file in "$LOG_DIR"/*.log; do
+                [ -e "$log_file" ] || continue
+                node=$(basename "$log_file" .log)
+                echo "#### $node"
+                echo ""
+                echo '```text'
+                tail -5 "$log_file" || true
+                echo '```'
+                echo ""
+            done
+        } > "$tmp" || true
+        mv "$tmp" "$out" || true
+        sleep 30 || true
+    done
+}
+
+heartbeat_start() {
+    local tier="$1"
+    _progress_heartbeat "$tier" &
+    HEARTBEAT_PID=$!
+}
+
+heartbeat_stop() {
+    if [ -n "${HEARTBEAT_PID:-}" ] && kill -0 "$HEARTBEAT_PID" 2>/dev/null; then
+        kill "$HEARTBEAT_PID" 2>/dev/null || true
+        wait "$HEARTBEAT_PID" 2>/dev/null || true
+    fi
+    HEARTBEAT_PID=""
 }
 
 # Output results as GitHub Actions job summary (markdown).

--- a/testlab/cloud/test-cloud.sh
+++ b/testlab/cloud/test-cloud.sh
@@ -60,6 +60,7 @@ done
 
 cleanup_on_exit() {
     local rc=$?
+    heartbeat_stop || true
     if [ "$SKIP_TEARDOWN" = "true" ]; then
         log_warn "Skipping teardown (--skip-teardown). VMs are still running!"
         collect_logs || true
@@ -1425,6 +1426,7 @@ if should_run_tier 1; then
     tier_start=$(date +%s)
     TIER_START_EPOCH[1]=$tier_start
     emit_event "tier_start" "tier_1" "tests=$TOTAL_TESTS_IN_TIER"
+    heartbeat_start "tier_1"
     run_test T1  "Basic mesh (3 nodes)"         test_t1_basic_mesh
     run_test T2  "Full mesh (${#NODE_IPS[@]} nodes)" test_t2_full_mesh
     run_test T3  "IPv6 mesh connectivity"        test_t3_ipv6
@@ -1434,6 +1436,7 @@ if should_run_tier 1; then
     collect_all_pprof  # baseline profiles after first mesh formation
     TIER_END_EPOCH[1]=$(date +%s)
     emit_event "tier_end" "tier_1"
+    heartbeat_stop
     log_bold "  Tier 1 complete in $(( TIER_END_EPOCH[1] - tier_start ))s"
 fi
 
@@ -1446,6 +1449,7 @@ if should_run_tier 2; then
     tier_start=$(date +%s)
     TIER_START_EPOCH[2]=$tier_start
     emit_event "tier_start" "tier_2" "tests=$TOTAL_TESTS_IN_TIER"
+    heartbeat_start "tier_2"
     run_test T5  "Late peer join"                test_t5_late_join
     run_test T6  "Graceful peer leave"           test_t6_graceful_leave
     run_test T7  "Peer crash (SIGKILL)"          test_t7_crash
@@ -1456,6 +1460,7 @@ if should_run_tier 2; then
     verify_data_plane
     TIER_END_EPOCH[2]=$(date +%s)
     emit_event "tier_end" "tier_2"
+    heartbeat_stop
     log_bold "  Tier 2 complete in $(( TIER_END_EPOCH[2] - tier_start ))s"
 fi
 
@@ -1468,6 +1473,7 @@ if should_run_tier 3; then
     tier_start=$(date +%s)
     TIER_START_EPOCH[3]=$tier_start
     emit_event "tier_start" "tier_3" "tests=$TOTAL_TESTS_IN_TIER"
+    heartbeat_start "tier_3"
     run_test T11 "10% packet loss (2 nodes)"     test_t11_loss_10
     run_test T12 "30% packet loss (1 node)"      test_t12_loss_30
     run_test T13 "50% packet loss (flap OK)"     test_t13_loss_50
@@ -1481,6 +1487,7 @@ if should_run_tier 3; then
     verify_data_plane
     TIER_END_EPOCH[3]=$(date +%s)
     emit_event "tier_end" "tier_3"
+    heartbeat_stop
     log_bold "  Tier 3 complete in $(( TIER_END_EPOCH[3] - tier_start ))s"
 fi
 
@@ -1493,6 +1500,7 @@ if should_run_tier 4; then
     tier_start=$(date +%s)
     TIER_START_EPOCH[4]=$tier_start
     emit_event "tier_start" "tier_4" "tests=$TOTAL_TESTS_IN_TIER"
+    heartbeat_start "tier_4"
     run_test T20 "Partial partition"             test_t20_partial_partition
     run_test T21 "Full node isolation"           test_t21_full_isolation
     run_test T22 "Split brain"                   test_t22_split_brain
@@ -1502,6 +1510,7 @@ if should_run_tier 4; then
     verify_data_plane
     TIER_END_EPOCH[4]=$(date +%s)
     emit_event "tier_end" "tier_4"
+    heartbeat_stop
     log_bold "  Tier 4 complete in $(( TIER_END_EPOCH[4] - tier_start ))s"
 fi
 
@@ -1514,6 +1523,7 @@ if should_run_tier 5; then
     tier_start=$(date +%s)
     TIER_START_EPOCH[5]=$tier_start
     emit_event "tier_start" "tier_5" "tests=$TOTAL_TESTS_IN_TIER"
+    heartbeat_start "tier_5"
     run_test T25 "Cone NAT"                      test_t25_cone_nat
     run_test T26 "Symmetric NAT"                 test_t26_symmetric_nat
     run_test T27 "Mixed NAT topology"            test_t27_mixed_nat
@@ -1525,6 +1535,7 @@ if should_run_tier 5; then
     verify_data_plane
     TIER_END_EPOCH[5]=$(date +%s)
     emit_event "tier_end" "tier_5"
+    heartbeat_stop
     log_bold "  Tier 5 complete in $(( TIER_END_EPOCH[5] - tier_start ))s"
 fi
 
@@ -1537,6 +1548,7 @@ if should_run_tier 6; then
     tier_start=$(date +%s)
     TIER_START_EPOCH[6]=$tier_start
     emit_event "tier_start" "tier_6" "tests=$TOTAL_TESTS_IN_TIER"
+    heartbeat_start "tier_6"
     run_test T32 "Rapid peer cycling"            test_t32_rapid_cycling
     run_test T33 "Rolling restart"               test_t33_rolling_restart
     run_test T34 "Simultaneous restart"          test_t34_simultaneous_restart
@@ -1552,6 +1564,7 @@ if should_run_tier 6; then
     verify_data_plane
     TIER_END_EPOCH[6]=$(date +%s)
     emit_event "tier_end" "tier_6"
+    heartbeat_stop
     log_bold "  Tier 6 complete in $(( TIER_END_EPOCH[6] - tier_start ))s"
 fi
 
@@ -1564,6 +1577,7 @@ if should_run_tier 7; then
     tier_start=$(date +%s)
     TIER_START_EPOCH[7]=$tier_start
     emit_event "tier_start" "tier_7" "tests=$TOTAL_TESTS_IN_TIER"
+    heartbeat_start "tier_7"
     run_test T43 "5-min clean soak"              test_t43_clean_soak
     run_test T44 "10-min chaos soak"             test_t44_chaos_soak
     run_test T45 "15-min long soak with churn"   test_t45_long_soak
@@ -1572,6 +1586,7 @@ if should_run_tier 7; then
     collect_all_pprof  # final profiles after full test suite
     TIER_END_EPOCH[7]=$(date +%s)
     emit_event "tier_end" "tier_7"
+    heartbeat_stop
     log_bold "  Tier 7 complete in $(( TIER_END_EPOCH[7] - tier_start ))s"
 fi
 


### PR DESCRIPTION
## Links

- docs/plans/2026-05-16-001-feat-hetzner-mid-run-heartbeat-plan.md
- docs/brainstorms/2026-05-15-hetzner-mid-run-visibility-requirements.md

## Summary

Adds a mid-run heartbeat for Hetzner cloud test tiers so long CI steps continuously rewrite the GitHub step summary with current tier state.
The heartbeat includes current test progress, cumulative results, recent trace events, per-VM log tails, and live soak packet stats when available.
`mesh_ping_soak` now writes an atomic in-flight snapshot during long ping soaks and removes it on exit.
Tier lifecycle hooks start and stop the heartbeat cleanly, while `run_test` emits live `::group::` and `::notice::` annotations for test boundaries.

## Test Plan

- [x] shellcheck testlab/cloud/lib.sh testlab/cloud/test-cloud.sh testlab/cloud/chaos.sh
- [x] go build -o /tmp/wgmesh-verify .
- [x] go test ./...
- [ ] Manual dispatch verifies live updates

Note: no auto-merge — caller will dispatch Hetzner run manually after review.
