### PR TITLE
fix(testlab): heartbeat + soak correctness fixes from #639 Copilot review

### DIFF
--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -399,13 +399,23 @@ mesh_ping_soak() {
         [ "$remaining" -lt "$count" ] && count="$remaining"
         [ "$count" -lt 1 ] && count=1
 
-        local chunk_out
+        local chunk_out="" chunk_rc=0
+        set +e
         chunk_out=$(RUN_ON_TIMEOUT_SEC=$((count + 30)) run_on "$from" "ping -i 1 -w $count -W 2 -q $to_ip 2>&1 || true")
+        chunk_rc=$?
+        set -e
         out="${out}${chunk_out}"$'\n'
 
-        local chunk_transmitted chunk_received
-        chunk_transmitted=$(echo "$chunk_out" | awk '/packets transmitted/ {print $1; exit}' || true)
-        chunk_received=$(echo "$chunk_out" | awk -F',' '/packets transmitted/ {gsub(/^[[:space:]]+/, "", $2); print $2 + 0; exit}' || true)
+        local chunk_transmitted="" chunk_received=""
+        if [ "$chunk_rc" -eq 0 ]; then
+            chunk_transmitted=$(echo "$chunk_out" | awk '/packets transmitted/ {print $1; exit}' || true)
+            chunk_received=$(echo "$chunk_out" | awk -F',' '/packets transmitted/ {gsub(/^[[:space:]]+/, "", $2); print $2 + 0; exit}' || true)
+        fi
+        if [ "$chunk_rc" -ne 0 ] || [ -z "$chunk_transmitted" ]; then
+            log_warn "soak: chunk failed (run_on rc=$chunk_rc) — counting as full loss for ${count}s window"
+            chunk_transmitted="$count"
+            chunk_received=0
+        fi
         transmitted=$(( transmitted + ${chunk_transmitted:-0} ))
         received=$(( received + ${chunk_received:-0} ))
         elapsed=$(( elapsed + count ))

--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -1096,20 +1096,6 @@ _progress_heartbeat() {
                 }
             ' || true
             echo ""
-
-            echo "### VM Log Tails"
-            echo ""
-            local log_file node
-            for log_file in "$LOG_DIR"/*.log; do
-                [ -e "$log_file" ] || continue
-                node=$(basename "$log_file" .log)
-                echo "#### $node"
-                echo ""
-                echo '```text'
-                tail -5 "$log_file" || true
-                echo '```'
-                echo ""
-            done
         } > "$tmp" || true
         mv "$tmp" "$out" || true
         sleep 30 || true

--- a/testlab/cloud/lib.sh
+++ b/testlab/cloud/lib.sh
@@ -989,7 +989,7 @@ _progress_heartbeat() {
                 function json_value(line, key, pattern, raw) {
                     pattern = "\"" key "\":\"[^\"]*\""
                     if (match(line, pattern)) {
-                        raw = substr(line, RSTART + length(key) + 4, RLENGTH - length(key) - 4)
+                        raw = substr(line, RSTART + length(key) + 4, RLENGTH - length(key) - 5)
                         return raw
                     }
                     pattern = "\"" key "\":[^,}]*"
@@ -1061,7 +1061,7 @@ _progress_heartbeat() {
                 function json_value(line, key, pattern, raw) {
                     pattern = "\"" key "\":\"[^\"]*\""
                     if (match(line, pattern)) {
-                        raw = substr(line, RSTART + length(key) + 4, RLENGTH - length(key) - 4)
+                        raw = substr(line, RSTART + length(key) + 4, RLENGTH - length(key) - 5)
                         gsub(/\|/, "\\|", raw)
                         return raw
                     }


### PR DESCRIPTION
## Summary

Three correctness fixes flagged by Copilot post-merge on PR #639. All in `testlab/cloud/lib.sh`.

- **P1 (CRITICAL):** awk JSON parser in `_progress_heartbeat` and the inline trace-tail awk had off-by-one substr math — closing `"` was included in returned string values. Comparisons against `test_start`, `test_end`, `PASS`, `FAIL`, `SKIP` never matched. The heartbeat's `Current test` field and trace-derived counts read empty/zero. ([Copilot comment on `lib.sh:998`](https://github.com/atvirokodosprendimai/wgmesh/pull/639#discussion_r-comment-998))
- **P3 (CRITICAL):** `mesh_ping_soak` swallowed `run_on` chunk failures (failed/timed-out SSH) by falling back to `${chunk_transmitted:-0}`. `elapsed` advanced anyway, so a soak could pass with whole 10s windows never measured — directly undermining the T28/T29 gate from PR #638. Now treats a failed chunk as full loss (`transmitted=count, received=0`) so the loss threshold catches the gap. ([Copilot comment on `lib.sh:410`](https://github.com/atvirokodosprendimai/wgmesh/pull/639#discussion_r-comment-410))
- **P2 (DESIGN):** Dropped the `### VM Log Tails` section from the heartbeat. `${LOG_DIR}/*.log` files are populated by `collect_logs` which only runs after the heartbeat stops, so the section showed empty/stale data during live runs. Trace events carry the live signal. ([Copilot comment on `lib.sh:1099`](https://github.com/atvirokodosprendimai/wgmesh/pull/639#discussion_r-comment-1099))

## Test plan

- [x] `shellcheck testlab/cloud/lib.sh testlab/cloud/test-cloud.sh testlab/cloud/chaos.sh` clean
- [x] `go build -o /tmp/wgmesh-verify .` clean
- [x] `go test ./...` all 13 packages pass
- [x] Local awk smoke: scratch trace.jsonl with 3 events → parser correctly extracts `current=T2 pass=1 fail=0 skip=0` (was extracting `test_start"`, `PASS"`, all unmatched)
- [ ] Hetzner dispatch post-merge: `gh workflow run hetzner-integration.yml -f tiers=5 -f vm_count=5` — verify (a) heartbeat `Current test` field tracks live, (b) trace-derived counts increment, (c) soak chunk failure path exercises only if SSH wedges

## Note

In-flight verification run [25954489120](https://github.com/atvirokodosprendimai/wgmesh/actions/runs/25954489120) (dispatched against PR #639's buggy code) will NOT see these fixes — a fresh dispatch post-merge is needed.

Do NOT auto-merge — caller will dispatch a fresh Hetzner run to verify before merge.