### PR TITLE
fix(ci): goose-triage uses app token, not expired PUSH_TOKEN

### DIFF
--- a/.github/workflows/goose-triage.yml
+++ b/.github/workflows/goose-triage.yml
@@ -26,12 +26,19 @@ jobs:
 
     steps:
       # ── Setup ──────────────────────────────────────────
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.PUSH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -61,7 +68,7 @@ jobs:
         id: issue
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PUSH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const issueNumber = context.issue.number;
@@ -239,14 +246,15 @@ jobs:
           git commit -m "spec: Issue #${ISSUE_NUM} - Goose triage"
           git push origin "$SPEC_BRANCH"
 
-      - name: Open spec PR and swap issue label
+      - name: Open spec PR
+        id: spec-pr
         uses: actions/github-script@v7
         env:
           ISSUE_NUM: ${{ steps.issue.outputs.issue_number }}
           SAFE_TITLE: ${{ steps.issue.outputs.safe_title }}
           SPEC_BRANCH: ${{ steps.issue.outputs.spec_branch }}
         with:
-          github-token: ${{ secrets.PUSH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const issueNum = process.env.ISSUE_NUM;
             const safeTitle = process.env.SAFE_TITLE;
@@ -269,11 +277,25 @@ jobs:
               ].join('\n')
             });
 
+            core.setOutput('pr_number', String(pr.number));
+            console.log(`Opened spec PR #${pr.number} for issue #${issueNum}`);
+
+      - name: Swap issue label
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUM: ${{ steps.issue.outputs.issue_number }}
+          PR_NUM: ${{ steps.spec-pr.outputs.pr_number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNum = process.env.ISSUE_NUM;
+            const prNum = process.env.PR_NUM;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: parseInt(issueNum),
-              body: `Goose-authored specification PR created: #${pr.number}`
+              body: `Goose-authored specification PR created: #${prNum}`
             });
 
             try {
@@ -294,4 +316,4 @@ jobs:
               labels: ['copilot-triaging']
             });
 
-            console.log(`Opened spec PR #${pr.number} and moved issue #${issueNum} to copilot-triaging`);
+            console.log(`Moved issue #${issueNum} to copilot-triaging`);


### PR DESCRIPTION
## Summary

Fixes `goose-triage.yml` to stop using the expired `secrets.PUSH_TOKEN` PAT and instead mint a GitHub App token from the pupabobas app with `actions/create-github-app-token@v1`.

## Root Cause

`secrets.PUSH_TOKEN` is expired, causing checkout/auth failures like `fatal: could not read Username` on checkout with exit 128.

## Blast Radius

Five workflows have been failing repeatedly: Auto-undraft 11, Spec Auto-Approve 11, E2E Watcher 9, Board Sync 9, and Goose Triage 1. This PR fixes only `.github/workflows/goose-triage.yml`; the remaining four workflows are a separate follow-up.

## Fix

- Add a first job step that generates an app token with `actions/create-github-app-token@v1` using `vars.APP_ID` and `secrets.APP_PRIVATE_KEY` for the pupabobas app.
- Use the app token for checkout, issue-context extraction, branch push credentials, and spec PR creation.
- Keep `secrets.GITHUB_TOKEN` for issue comment and label operations because the app token does not have `issues:write`.

The app token is regenerated per run, so it does not expire like the old PAT. Because it is a non-`GITHUB_TOKEN` principal, branches and PRs created by this workflow still trigger downstream workflows such as spec-validation, which `GITHUB_TOKEN`-authored events would suppress.

## Mixed-token Rationale

The app token is used where trigger propagation matters: checkout, push, and PR creation. `GITHUB_TOKEN` is intentionally retained for the label-swap path because the workflow permissions block grants `issues: write`, while the app lacks `issues:write`.

## Unchanged

The sanitise gate, empty-output guard, recipe, and PR-title format are unchanged.

## Validation

- `yamllint .github/workflows/goose-triage.yml`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/goose-triage.yml'))"`
- `grep -n "PUSH_TOKEN" .github/workflows/goose-triage.yml` returned zero lines
- `grep -n "app-token\|APP_ID\|APP_PRIVATE_KEY" .github/workflows/goose-triage.yml` shows the mint step and usages
- `grep -c "GITHUB_TOKEN" .github/workflows/goose-triage.yml` returned `1`