### PR TITLE
fix(ci): spec-auto-approve approves as github-actions, not self (app token)

### DIFF
--- a/.github/workflows/spec-auto-approve.yml
+++ b/.github/workflows/spec-auto-approve.yml
@@ -174,7 +174,7 @@ jobs:
           echo "Auto-approving spec PR #$PR_NUM"
 
           # Approve the PR
-          gh pr review $PR_NUM --approve --body "## Auto-Approved ✅
+          GH_TOKEN="$ISSUE_WRITE_TOKEN" gh pr review $PR_NUM --approve --body "## Auto-Approved ✅
 
           This spec PR passed all validation checks:
 
@@ -409,7 +409,7 @@ jobs:
                 // All checks passed — approve and trigger Goose
                 core.info(`PR #${pr.number}: all checks passed, approving`);
 
-                await github.rest.pulls.createReview({
+                await issueGithub.rest.pulls.createReview({
                   owner, repo,
                   pull_number: pr.number,
                   event: 'APPROVE',


### PR DESCRIPTION
* Root cause: spec PR #663 opened by app/pupabobas; spec-auto-approve also approved via app token → GitHub 422 "You can not approve your own pull request"; set -e → fatal before label-add and goose-build dispatch
* Fix: route gh pr review --approve (bash path) and createReview (scheduled path) through GITHUB_TOKEN (github-actions[bot] = different principal from PR author)
* Principal split rationale: approve → GITHUB_TOKEN (satisfies self-approval prohibition); label add → GITHUB_TOKEN (app lacks issues:write); goose-build dispatch → app token (non-GITHUB_TOKEN required to trigger downstream workflow runs)
* Only spec-auto-approve.yml changed