### PR TITLE
fix(ci): board-sync best-effort (dead PUSH_TOKEN 401 must not fail every PR)

### DIFF
--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -30,6 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Move item to correct column
+        # Best-effort board cosmetics: a dead/expired PUSH_TOKEN (401 Bad
+        # credentials on the Projects GraphQL API) must not fail-loud on every
+        # PR. Rotate PUSH_TOKEN (or migrate to an app token with Projects
+        # write) to restore live board sync.
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PUSH_TOKEN }}


### PR DESCRIPTION
Sync Board Status fails 401 Bad credentials on every PR — PUSH_TOKEN is expired (Projects GraphQL). Board sync is cosmetic; add continue-on-error so it does not fail-loud. Rotate PUSH_TOKEN or migrate to an app token with Projects write to restore live sync.