### PR TITLE
fix(ci): impl-merged-close uses github.token (PUSH_TOKEN expired)

### DIFF
--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Ensure verification + tests labels exist
         env:
-          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh label create awaiting-verification \
             --repo "${{ github.repository }}" \
@@ -88,7 +88,7 @@ jobs:
       - name: Close linked issue, gate on tests, or send to verification
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.PUSH_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const handler = require('./scripts/workflows/impl-merged-close-handler.js');
             await handler({github, context, core});


### PR DESCRIPTION
## Problem
`Implementation Merged — Close Issue` fails on every merged PR with `Error: Input required and not supplied: github-token` (latest: run 2026-06-09T20:13Z after #664 merge). `secrets.PUSH_TOKEN` is the expired PAT — the known root of the wgmesh workflow stall.

## Fix
Replace both `secrets.PUSH_TOKEN` uses with `github.token`:
- line 75 (`gh label create`) — same-repo label ops; was failing silently behind `|| true`
- line 91 (`actions/github-script` close-issue handler) — same-repo issue/PR ops; failing loudly

The workflow's `permissions` block already grants `issues: write`, `pull-requests: read`, `contents: read` — sufficient for both steps. No downstream workflow depends on events emitted by this one (e2e-verifier triggers on `pull_request: closed` directly), so the github-actions principal's no-retrigger property is not a regression.

## Follow-up (separate)
PUSH_TOKEN still referenced in 10 other workflows (approve-build, auto-merge, board-sync, bot-pr-review-merge, e2e-verify-close, goose-review, pulse, release, spec-merged-build, verify-comment-close). App-token migration (vars.APP_ID + secrets.APP_PRIVATE_KEY) tracked separately.