### PR TITLE
fix(ci): spec-auto-approve needs actions:write to dispatch goose-build

### DIFF
--- a/.github/workflows/spec-auto-approve.yml
+++ b/.github/workflows/spec-auto-approve.yml
@@ -29,6 +29,9 @@ permissions:
   pull-requests: write
   contents: write
   issues: write
+  # createWorkflowDispatch(goose-build.yml) needs actions:write — without it
+  # the dispatch 403s "Resource not accessible by integration" after approval.
+  actions: write
 
 jobs:
   # ── Event-driven path: runs immediately when a spec PR is opened/edited ──


### PR DESCRIPTION
## Problem
Scheduled sweep run 27239266106 (2026-06-09T22:12Z) approved spec PR #667 and added `approved-for-build`, but the follow-up `createWorkflowDispatch(goose-build.yml)` failed: `PR #667: error: Resource not accessible by integration`. The workflow's permissions block grants `pull-requests/contents/issues: write` but not `actions: write`, which workflow-dispatch requires.

This is the only build-trigger path for sweep-approved PRs: the label is added by `GITHUB_TOKEN`, and GITHUB_TOKEN-created events don't fire goose-build's `pull_request: [labeled]` trigger.

## Fix
Add `actions: write` to the permissions block (with a comment stating the constraint).

## Verification
After merge, the next scheduled sweep approving a refreshed spec PR should produce a `goose-build` workflow_dispatch run. #667 (already approved, sweep now skips it) gets a manual goose-build dispatch.