### PR TITLE
fix(ci): dispatch goose-build via GITHUB_TOKEN client — app token lacks actions perm

### DIFF
--- a/.github/workflows/spec-auto-approve.yml
+++ b/.github/workflows/spec-auto-approve.yml
@@ -192,8 +192,11 @@ jobs:
           GH_TOKEN="$ISSUE_WRITE_TOKEN" gh pr edit $PR_NUM --add-label approved-for-build
 
           # Directly trigger Goose implementation via workflow_dispatch.
+          # GITHUB_TOKEN, not the app token: the app installation has no `actions`
+          # permission, so dispatching with it fails "Resource not accessible by
+          # integration". actions:write comes from this workflow's permissions block.
           echo "Triggering Goose implementation for issue #${ISSUE_NUM} (spec PR #${PR_NUM})"
-          gh workflow run goose-build.yml \
+          GH_TOKEN="$ISSUE_WRITE_TOKEN" gh workflow run goose-build.yml \
             -f issue_number="${ISSUE_NUM}" \
             -f spec_pr_number="${PR_NUM}"
 

--- a/.github/workflows/spec-auto-approve.yml
+++ b/.github/workflows/spec-auto-approve.yml
@@ -436,7 +436,12 @@ jobs:
                   labels: ['approved-for-build'],
                 });
 
-                await github.rest.actions.createWorkflowDispatch({
+                // Dispatch through the GITHUB_TOKEN client (issueGithub): the default
+                // `github` client here is the app token, and the app installation has
+                // no `actions` permission - dispatching with it 403s
+                // "Resource not accessible by integration". GITHUB_TOKEN carries
+                // actions:write from this workflow's permissions block.
+                await issueGithub.rest.actions.createWorkflowDispatch({
                   owner, repo,
                   workflow_id: 'goose-build.yml',
                   ref: 'main',


### PR DESCRIPTION
## Problem
Sweeps after #704 still fail dispatch: `##[warning]PR #NNN: error: Resource not accessible by integration` on `POST /actions/workflows/goose-build.yml/dispatches` (runs 27243130117, 27247862938 — all 6 approved PRs, zero builds dispatched).

#704 added `actions: write` to the workflow's permissions block, but that only affects `GITHUB_TOKEN`. The scan job's default `github` octokit client is constructed from the **app token** (`github-token: steps.app-token.outputs.token`), and the pupabobas installation has no `actions` permission (app perms are UI-managed, not yaml).

## Fix
Route `createWorkflowDispatch` through `issueGithub` — the GITHUB_TOKEN client already used for `createReview`/`addLabels` since #664 — which now carries `actions: write` from the permissions block.

## Verification
Next sweep approving an unlabeled spec PR must produce a goose-build `workflow_dispatch` run. The 7 already-labeled PRs get manual dispatches (sweep skips labeled PRs by design).