### PR TITLE
fix(ci): bot-pr-review-merge uses app token — PUSH_TOKEN expired killed merge lane

### DIFF
--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -50,9 +50,19 @@ jobs:
         with:
           ref: main
 
+      # App token, not PUSH_TOKEN (expired PAT, lane dead since ~06-07: "GH_TOKEN
+      # must be set") and not GITHUB_TOKEN (its merge events would not trigger
+      # the downstream impl-merged-close / spec-merged-build chain).
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Autonomous PR review and merge
         env:
-          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           APPROVED_AUTHORS: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
## Problem
The merge lane dies on every PR: `company/scripts/pr-review-merge.sh: line 35: GH_TOKEN: GH_TOKEN must be set` (latest: run for impl PR #710, 05:06Z). `secrets.PUSH_TOKEN` is the expired PAT.

All 5 fresh goose impl PRs (#706-#710, CI green, needs-review) are stuck behind this.

## Fix
Generate a pupabobas app token (`vars.APP_ID` + `secrets.APP_PRIVATE_KEY`) and feed it as `GH_TOKEN`.

Why app token and not `github.token`: merges performed with `GITHUB_TOKEN` emit events that do NOT trigger other workflows, which would silently break the downstream chain (impl-merged-close, spec-merged-build, e2e-verifier on PR close). App-principal merges trigger normally.

## After merge
The 5 impl PRs get re-triggered through the lane (close/reopen — workflow fires on opened/reopened only; the synchronize-gap is a known separate issue).

Part of the PUSH_TOKEN migration: 9 workflows still reference it (approve-build, auto-merge, board-sync, e2e-verify-close, goose-review, pulse, release, spec-merged-build, verify-comment-close).