### PR TITLE
fix(ci): goose-review tokens — github.token for API ops, app token for push

### DIFF
--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -118,6 +118,7 @@ jobs:
       # GITHUB_TOKEN push would emit no synchronize event - CI would never
       # re-run on the fixed branch.
       - name: Generate app token
+        if: steps.pr.outputs.skip != 'true'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:

--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -42,7 +42,7 @@ jobs:
         id: pr
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PUSH_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const prNumber = parseInt('${{ github.event.inputs.pr_number }}', 10);
             const owner = context.repo.owner;
@@ -294,7 +294,7 @@ jobs:
         if: steps.pr.outputs.skip != 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PUSH_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const prNumber = parseInt('${{ github.event.inputs.pr_number }}', 10);
             const gooseOk = '${{ steps.goose.outputs.goose_ok }}' === 'true';
@@ -356,7 +356,7 @@ jobs:
         if: steps.pr.outputs.skip != 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PUSH_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const prNumber = parseInt('${{ github.event.inputs.pr_number }}', 10);
             const gooseOk = '${{ steps.goose.outputs.goose_ok }}' === 'true';

--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -114,11 +114,21 @@ jobs:
         if: steps.pr.outputs.skip == 'true'
         run: echo "No unresolved Copilot threads — exiting cleanly."
 
+      # App token for checkout/push: the PAT (PUSH_TOKEN) is expired, and a
+      # GITHUB_TOKEN push would emit no synchronize event - CI would never
+      # re-run on the fixed branch.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         if: steps.pr.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PUSH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Copy recipe from main before switching branches


### PR DESCRIPTION
## Problem
goose-review (the Copilot-findings → Goose fix loop) runs on expired `PUSH_TOKEN` in 4 places — the lane that should drive impl PRs #706-#710 from COMMENTED to APPROVED is dead.

## Fix
- 3× `actions/github-script` (fetch threads / resolve threads / comment): `github.token` — same-repo PR ops, `pull-requests: write` already declared.
- checkout/push: pupabobas app token — a GITHUB_TOKEN push emits no `synchronize` event, so CI would never re-run on the fixed branch.

Part of the PUSH_TOKEN migration (8 workflows left: approve-build, auto-merge, board-sync, e2e-verify-close, pulse, release, spec-merged-build, verify-comment-close).