### PR TITLE
fix(ci): goose-review cascade — working z.ai leg, catch provider 404s, resolve only after real push

### DIFF
--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -192,9 +192,8 @@ jobs:
 
           RECIPE=".github/goose-recipes/wgmesh-review.yaml"
 
-          # Cascade: GLM-5 via Z.ai direct (subscription) → Claude Sonnet via OpenRouter.
-          # Z.ai exposes an OpenAI-compatible API, so Goose uses the "openai" provider
-          # with OPENAI_HOST pointed at Z.ai's coding endpoint.
+          # Cascade: GLM-4.6 via Z.ai direct (subscription, anthropic-compatible
+          # endpoint) → OpenRouter BYOK fallbacks.
           run_goose() {
             local provider="$1" model="$2" label="$3"
             echo "::group::Trying $label ($provider/$model)"
@@ -233,8 +232,8 @@ jobs:
 
           goose_ok=false
 
-          # Cascade: Z.ai GLM-5 → OpenRouter BYOK models (GPT-5.4 → Mistral → Venice)
-          # GLM-5 uses Z.ai direct (subscription). The rest use OpenRouter with BYOK keys
+          # Cascade: Z.ai GLM-4.6 → OpenRouter BYOK models (GPT-5.4 → Mistral → Venice)
+          # GLM-4.6 uses Z.ai direct (subscription). The rest use OpenRouter with BYOK keys
           # so no OpenRouter credits are consumed.
 
           # 1. GLM-4.6 via Z.ai direct (GLM Coding Plan subscription).

--- a/.github/workflows/goose-review.yml
+++ b/.github/workflows/goose-review.yml
@@ -209,7 +209,7 @@ jobs:
               2>&1 | tee /tmp/goose-review-output.log || code=$?
 
             # Check for credit/auth/model errors
-            if grep -qiE '(add more credits|insufficient.*(funds|credits|balance)|rate.limit|unauthorized|api.key.not.found|model.*not.*found|not.*available)' /tmp/goose-review-output.log; then
+            if grep -qiE '(add more credits|insufficient.*(funds|credits|balance)|rate.limit|unauthorized|api.key.not.found|model.*not.*found|not.*available|request failed|resource not found)' /tmp/goose-review-output.log; then
               echo "::warning::$label: error detected, trying next provider"
               git checkout -- . 2>/dev/null || true
               git clean -fd 2>/dev/null || true
@@ -237,13 +237,15 @@ jobs:
           # GLM-5 uses Z.ai direct (subscription). The rest use OpenRouter with BYOK keys
           # so no OpenRouter credits are consumed.
 
-          # 1. GLM-5 via Z.ai direct (GLM Coding Plan subscription)
+          # 1. GLM-4.6 via Z.ai direct (GLM Coding Plan subscription).
+          # Anthropic-compatible endpoint - the SAME config the pipeline box and
+          # spec recipe use in production. The previous openai-compat leg
+          # (glm-5 at /api/coding/paas/v4) 404d on every run.
           if [ "$goose_ok" = false ] && [ -n "$ZAI_API_KEY" ]; then
-            export OPENAI_API_KEY="$ZAI_API_KEY"
-            export OPENAI_HOST="https://api.z.ai"
-            export OPENAI_BASE_PATH="/api/coding/paas/v4"
-            run_goose "openai" "glm-5" "Z.ai GLM-5" && goose_ok=true
-            unset OPENAI_API_KEY OPENAI_HOST OPENAI_BASE_PATH
+            export ANTHROPIC_API_KEY="$ZAI_API_KEY"
+            export ANTHROPIC_HOST="https://api.z.ai/api/anthropic"
+            run_goose "anthropic" "glm-4.6" "Z.ai GLM-4.6" && goose_ok=true
+            unset ANTHROPIC_API_KEY ANTHROPIC_HOST
           fi
 
           # 2. GPT-5.4 via OpenRouter (BYOK: OpenAI key)
@@ -301,8 +303,10 @@ jobs:
             echo "changes=none" >> "$GITHUB_OUTPUT"
           fi
 
+      # Only after a real push: resolving threads when Goose changed nothing
+      # dismissed findings without fixes (runs 06:37Z 2026-06-10, 9 threads on #706).
       - name: Resolve Copilot review threads
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.pr.outputs.skip != 'true' && steps.push.outputs.changes == 'pushed'
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}


### PR DESCRIPTION
## Problem (found verifying first live runs, 06:37Z)
All 5 goose-review runs 'succeeded' while doing nothing — and **resolved 9 Copilot threads on #706 (45 total across 5 PRs) without any fix pushed**:
1. Leg 1 `openai/glm-5` at `OPENAI_BASE_PATH=/api/coding/paas/v4` 404s instantly (`Request failed: Resource not found (404)`).
2. The error-grep doesn't match that string → exit-0 goose treated as success → `goose_ok=true`, remaining cascade legs never tried.
3. Thread resolution gated only on `goose_ok` → findings dismissed with zero changes.

## Fix
1. Leg 1 → `anthropic/glm-4.6` with `ANTHROPIC_HOST=https://api.z.ai/api/anthropic` — the exact config the pipeline box + spec recipe use in production.
2. Error-grep adds `request failed|resource not found`.
3. `Resolve Copilot review threads` requires `steps.push.outputs.changes == 'pushed'` — no-change runs leave threads for attention.

## Note
The 45 falsely-resolved threads are left as-is: a fresh Copilot re-review (requested only after a real fix lands) re-evaluates the full diff regardless of old thread state.