### PR TITLE
chore(ci): retire the Actions implementation lane — the box owns implement

### DIFF
--- a/.github/workflows/goose-build.yml
+++ b/.github/workflows/goose-build.yml
@@ -6,9 +6,11 @@ name: Goose Implementation
 # 1. A spec PR is labeled 'approved-for-build' (normal flow)
 # 2. Manually via workflow_dispatch (re-trigger for merged PRs or retries)
 
+# The pipeline box (live mode) owns implementation since 2026-06-10 — it
+# implements from approved specs on bot/impl-N branches. This Actions lane
+# stays manual-only for emergencies; the labeled trigger raced the box and
+# produced duplicate implementations (pulse 2026-06-10).
 'on':
-  pull_request:
-    types: [labeled]
   workflow_dispatch:
     inputs:
       issue_number:

--- a/.github/workflows/spec-auto-approve.yml
+++ b/.github/workflows/spec-auto-approve.yml
@@ -196,11 +196,9 @@ jobs:
           # permission, so dispatching with it fails "Resource not accessible by
           # integration". actions:write comes from this workflow's permissions block.
           echo "Triggering Goose implementation for issue #${ISSUE_NUM} (spec PR #${PR_NUM})"
-          GH_TOKEN="$ISSUE_WRITE_TOKEN" gh workflow run goose-build.yml \
-            -f issue_number="${ISSUE_NUM}" \
-            -f spec_pr_number="${PR_NUM}"
-
-          echo "Goose implementation triggered"
+          # goose-build dispatch removed 2026-06-10: the pipeline box (live
+          # mode) implements from approved specs; the Actions lane raced it.
+          echo "Approved — pipeline box will implement"
 
       # ── Agent metrics: spec validation ────────────────
       - name: Collect agent metrics
@@ -444,15 +442,10 @@ jobs:
                 // no `actions` permission - dispatching with it 403s
                 // "Resource not accessible by integration". GITHUB_TOKEN carries
                 // actions:write from this workflow's permissions block.
-                await issueGithub.rest.actions.createWorkflowDispatch({
-                  owner, repo,
-                  workflow_id: 'goose-build.yml',
-                  ref: 'main',
-                  inputs: {
-                    issue_number: issueNum,
-                    spec_pr_number: String(pr.number),
-                  },
-                });
+                // goose-build dispatch removed 2026-06-10: the pipeline box
+                // (live mode) implements from approved specs; the Actions lane
+                // raced it (duplicate implementations, pulse 2026-06-10).
+                core.info(`PR #${pr.number}: approved — pipeline box will implement`);
 
                 core.info(`PR #${pr.number}: approved + Goose triggered for issue #${issueNum}`);
 

--- a/.github/workflows/spec-merged-build.yml
+++ b/.github/workflows/spec-merged-build.yml
@@ -1,12 +1,10 @@
 name: Spec Merged — Trigger Build
 
+# Retired as auto-trigger 2026-06-10: the pipeline box (live mode) implements
+# from approved specs directly; assigning a Copilot build agent on spec merge
+# raced it (failed run on #715, pulse 2026-06-10). Manual dispatch only.
 on:
-  # pull_request_target so Copilot-coding-agent `copilot/*` spec PRs do
-  # not freeze in `action_required` during their draft phase. Safe for
-  # the closed-merged path: merge is already on main and maintainer-
-  # approved by the time we fire. See #79 (extended scope).
-  pull_request_target:
-    types: [closed]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Pulse 2026-06-10 found the legacy Actions implement lane racing the live pipeline box: the (now-working) sweep dispatch fired goose-build (failed at push, 11:37Z) and #715's merge fired spec-merged-build's Copilot build assignment (failed, 13:50Z) — duplicate implementation paths for work the box already owns.

- `goose-build.yml`: `pull_request: [labeled]` trigger removed — manual dispatch only (emergency lane)
- `spec-auto-approve.yml`: both goose-build dispatch sites removed (approval + label remain — they gate spec merge)
- `spec-merged-build.yml`: auto-trigger removed — manual only

Box flow (spec→implement→verify→gate on bot/impl-N) is the single implementation lane.