### PR TITLE
feat(landing): OpenPanel analytics — track Polar CTA clicks

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -208,6 +208,18 @@ footer { text-align: center; color: var(--muted); font-size: 0.75rem; padding: 2
 .cap-partial { color: var(--yellow); }
 .cap-later { color: var(--muted); }
 </style>
+    <!-- OpenPanel analytics (self-hosted at counter.hackrsvalv.com) -->
+    <script src="https://openpanel.dev/op1.js" defer async></script>
+    <script>
+      window.op = window.op || function(...args) { (window.op.q = window.op.q || []).push(args); };
+      window.op('init', {
+        clientId: '80920d68-b57d-4c7b-baf6-3518495a3739',
+        apiUrl: 'https://counter.hackrsvalv.com/api',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -147,6 +147,18 @@
             text-decoration: none;
         }
     </style>
+    <!-- OpenPanel analytics (self-hosted at counter.hackrsvalv.com) -->
+    <script src="https://openpanel.dev/op1.js" defer async></script>
+    <script>
+      window.op = window.op || function(...args) { (window.op.q = window.op.q || []).push(args); };
+      window.op('init', {
+        clientId: '80920d68-b57d-4c7b-baf6-3518495a3739',
+        apiUrl: 'https://counter.hackrsvalv.com/api',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
 </head>
 <body>
     <header>

--- a/public/index.html
+++ b/public/index.html
@@ -191,6 +191,18 @@
             }
         }
     </style>
+    <!-- OpenPanel analytics (self-hosted at counter.hackrsvalv.com) -->
+    <script src="https://openpanel.dev/op1.js" defer async></script>
+    <script>
+      window.op = window.op || function(...args) { (window.op.q = window.op.q || []).push(args); };
+      window.op('init', {
+        clientId: '80920d68-b57d-4c7b-baf6-3518495a3739',
+        apiUrl: 'https://counter.hackrsvalv.com/api',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
 </head>
 <body>
     <header>

--- a/wgmesh.dev/index.html
+++ b/wgmesh.dev/index.html
@@ -121,6 +121,18 @@
             }
         }
     </style>
+    <!-- OpenPanel analytics (self-hosted at counter.hackrsvalv.com) -->
+    <script src="https://openpanel.dev/op1.js" defer async></script>
+    <script>
+      window.op = window.op || function(...args) { (window.op.q = window.op.q || []).push(args); };
+      window.op('init', {
+        clientId: '80920d68-b57d-4c7b-baf6-3518495a3739',
+        apiUrl: 'https://counter.hackrsvalv.com/api',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
 </head>
 <body>
     <header>


### PR DESCRIPTION
Adds the OpenPanel tracker (self-hosted at counter.hackrsvalv.com) to the 4 landing pages (`index.html`, `public/index.html`, `wgmesh.dev/index.html`, `docs/index.html`). Reuses the proven config from `evolution/wgmesh-cdn-slides.html` (clientId 80920d68-…).

Why: landing pages had **zero analytics** — Polar checkout clicks were invisible. `trackOutgoingLinks:true` auto-captures the Polar CTAs (outbound links), giving first funnel visibility. clientId+apiUrl already public in the slides file → no secret. 12 lines/file, idempotent insert before `</head>`.