### PR TITLE
docs(outreach): Polar checkout links + send-ready outreach

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -208,6 +208,18 @@ footer { text-align: center; color: var(--muted); font-size: 0.75rem; padding: 2
 .cap-partial { color: var(--yellow); }
 .cap-later { color: var(--muted); }
 </style>
+    <!-- OpenPanel analytics (self-hosted at counter.hackrsvalv.com) -->
+    <script src="https://openpanel.dev/op1.js" defer async></script>
+    <script>
+      window.op = window.op || function(...args) { (window.op.q = window.op.q || []).push(args); };
+      window.op('init', {
+        clientId: '80920d68-b57d-4c7b-baf6-3518495a3739',
+        apiUrl: 'https://counter.hackrsvalv.com/api',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -147,6 +147,18 @@
             text-decoration: none;
         }
     </style>
+    <!-- OpenPanel analytics (self-hosted at counter.hackrsvalv.com) -->
+    <script src="https://openpanel.dev/op1.js" defer async></script>
+    <script>
+      window.op = window.op || function(...args) { (window.op.q = window.op.q || []).push(args); };
+      window.op('init', {
+        clientId: '80920d68-b57d-4c7b-baf6-3518495a3739',
+        apiUrl: 'https://counter.hackrsvalv.com/api',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
 </head>
 <body>
     <header>

--- a/memory/outreach - 2602240805 - show hn post draft.md
+++ b/memory/outreach - 2602240805 - show hn post draft.md
@@ -1,9 +1,10 @@
 ---
-tldr: Draft Show HN post for wgmesh — autonomous pipeline + WireGuard CDN
-status: draft
+tldr: Show HN post for wgmesh — autonomous pipeline + WireGuard CDN
+status: ready
+updated: 2026-06-18
 ---
 
-# Show HN: Draft
+# Show HN: Ready to post
 
 **Title:**
 Show HN: I built a zero-infra anycast CDN on WireGuard mesh — with an AI pipeline that specs, codes, and ships itself
@@ -41,7 +42,10 @@ What isn't done yet:
 - Multi-region failover with real SLA guarantees
 - A polished onboarding path for adding your own edge node
 
-I'm opening two early sponsor tiers: $5/mo founding member (listed on the dashboard, Discord/Matrix access, votes on roadmap) and $20/mo edge node beta (early access to run a node in the mesh when that's ready).
+I'm opening early backer tiers via Polar.sh (one-click checkout, no account dance):
+- $5/mo founding member — listed on the dashboard, Discord/Matrix access, votes on roadmap: https://polar.sh/checkout?productId=3f5d75de-936b-49d8-a21b-4b79d9fd22c1
+- $20/mo edge node beta — early access to run a node in the mesh when that's ready: https://polar.sh/checkout?productId=1927e637-4cfd-4c94-8bee-c5518803bc89
+
 These are honest early backer tiers, not a product you're buying.
 
 Code: github.com/atvirokodosprendimai/wgmesh
@@ -55,3 +59,11 @@ Happy to answer questions on the mesh architecture, the pipeline design, or the 
 
 - https://news.ycombinator.com/submit (Show HN — title + URL = chimney.beerpub.dev or github.com/atvirokodosprendimai/wgmesh)
 - Post on a weekday between 8–11am US Eastern for best visibility
+
+## Pre-post checklist (2026-06-18)
+
+- [ ] Polar checkout links live + tested (productIds verified in #376)
+- [ ] Landing pages have OpenPanel analytics (shipped #762) — watch the funnel during the HN spike
+- [ ] Buttondown subscribe form live (for non-buyers from the HN traffic) — needs the wgmesh newsletter created
+- [ ] chimney.beerpub.dev up + presentable
+- [ ] Be available to answer comments for the first 2–3h after posting

--- a/memory/outreach - 2602240805 - stargazer dm template.md
+++ b/memory/outreach - 2602240805 - stargazer dm template.md
@@ -1,26 +1,20 @@
 ---
-tldr: Personalised outreach to 5 wgmesh stargazers — founding member conversion
+tldr: Personalised outreach to wgmesh stargazers — founding member conversion
 status: ready
+updated: 2026-06-18
 ---
 
 # Stargazer Outreach
 
-## Target list (5 stargazers as of 2026-02-24)
+Polar checkout (Founding Member $5/mo): https://polar.sh/checkout?productId=3f5d75de-936b-49d8-a21b-4b79d9fd22c1
 
-### 1. nycterent (Marty)
-- **Bio:** Linux sysadmin
-- **Email:** saint@ghost.lt
-- **Repos:** arscontexta (Claude Code plugin), coroot (observability), guardrails (LLM), devswarm
-- **Angle:** Fellow AI-tooling builder, uses observability tools we also use (Coroot)
-- **Contact:** Email
+> NOTE 2026-06-18: links updated GitHub Sponsors → Polar.sh checkout (#376 resolved).
+> Self (nycterent) removed from target list. 4 real external targets below.
+> Need to grow this list — only 4 external stargazers identified; add more as stars come in.
 
-> Hey Marty — noticed you starred wgmesh, thanks.
-> Saw you're building arscontexta and working with Coroot — we actually use Coroot for our pipeline observability too.
-> I'm keeping the founding member tier small on purpose: $5/mo gets your name on the chimney.beerpub.dev dashboard, Discord/Matrix access, and a direct vote on what gets built next.
-> Link if you're interested: https://github.com/sponsors/atvirokodosprendimai
-> No pressure — the code stays open regardless.
+## Target list (4 external stargazers)
 
-### 2. blinkinglight (M)
+### 1. blinkinglight (M)
 - **Bio:** Developer at @ituoga
 - **Location:** Lithuania
 - **Email:** mz@9g.lt
@@ -30,10 +24,10 @@ status: ready
 
 > Hey M — noticed you starred wgmesh, appreciate it.
 > Saw your Go work (bee, proxmox-api-go) — wgmesh is Go too, and if you're running Proxmox you're exactly the kind of person this is built for: mesh your homelab nodes without fiddling with WireGuard configs.
-> Founding member tier is $5/mo — name on the dashboard, Discord/Matrix, roadmap votes: https://github.com/sponsors/atvirokodosprendimai
-> No pressure either way.
+> Founding member tier is $5/mo — name on the dashboard, Discord/Matrix, roadmap votes: https://polar.sh/checkout?productId=3f5d75de-936b-49d8-a21b-4b79d9fd22c1
+> No pressure either way — code stays open regardless.
 
-### 3. neoromantique (Dave)
+### 2. neoromantique (Dave)
 - **Bio:** Transire benefaciendo
 - **Location:** Central Europe
 - **Blog:** aizenberg.co.uk
@@ -43,10 +37,10 @@ status: ready
 
 > Hey Dave — noticed you starred wgmesh, thanks.
 > Saw your sshs fork — if you're managing multiple SSH hosts, wgmesh can mesh them so they all talk to each other without port forwarding or public IPs.
-> I'm keeping the founding member tier small: $5/mo, name on the dashboard, Discord/Matrix, roadmap votes: https://github.com/sponsors/atvirokodosprendimai
+> I'm keeping the founding member tier small: $5/mo, name on the dashboard, Discord/Matrix, roadmap votes: https://polar.sh/checkout?productId=3f5d75de-936b-49d8-a21b-4b79d9fd22c1
 > No pressure — code stays open regardless.
 
-### 4. cablehead (Andy Gayton)
+### 3. cablehead (Andy Gayton)
 - **Location:** Toronto
 - **Blog:** ndyg.ca
 - **Twitter:** @cablelounger
@@ -57,44 +51,43 @@ status: ready
 
 > Hey Andy — noticed you starred wgmesh, appreciate it.
 > Saw your cross.stream work and http-nu — you're clearly thinking about stream infrastructure. wgmesh does the network layer: mesh your nodes with WireGuard + DHT discovery, no central coordinator.
-> Founding member tier is small on purpose: $5/mo, name on the dashboard, Discord/Matrix, roadmap votes: https://github.com/sponsors/atvirokodosprendimai
+> Founding member tier is small on purpose: $5/mo, name on the dashboard, Discord/Matrix, roadmap votes: https://polar.sh/checkout?productId=3f5d75de-936b-49d8-a21b-4b79d9fd22c1
 > No pressure either way — the code stays open regardless.
 
-### 5. nickchomey
+### 4. nickchomey
 - **Repos:** jjui (Jujutsu TUI, Go), rxdb fork, datastar-typescript, wordpress-develop
 - **Angle:** Interested in developer tooling (VCS, reactive DBs)
 - **Contact:** GitHub Discussion @mention (no email/twitter visible)
 
 > Hey — noticed you starred wgmesh, thanks.
 > If you're running any services across machines (homelab, VPS, etc.), wgmesh handles the WireGuard mesh automatically — no manual config, NAT traversal built in.
-> Founding member tier is $5/mo: name on the dashboard, Discord/Matrix, roadmap votes: https://github.com/sponsors/atvirokodosprendimai
+> Founding member tier is $5/mo: name on the dashboard, Discord/Matrix, roadmap votes: https://polar.sh/checkout?productId=3f5d75de-936b-49d8-a21b-4b79d9fd22c1
 > No pressure — code stays open regardless.
 
 ## How to send
 
 | # | User | Method | Address |
 |---|------|--------|---------|
-| 1 | nycterent | Email | saint@ghost.lt |
-| 2 | blinkinglight | Email | mz@9g.lt |
-| 3 | neoromantique | GitHub Discussion @mention | — |
-| 4 | cablehead | Twitter DM or email | @cablelounger / andy@thecablelounge.com |
-| 5 | nickchomey | GitHub Discussion @mention | — |
+| 1 | blinkinglight | Email | mz@9g.lt |
+| 2 | neoromantique | GitHub Discussion @mention | — |
+| 3 | cablehead | Twitter DM or email | @cablelounger / andy@thecablelounge.com |
+| 4 | nickchomey | GitHub Discussion @mention | — |
 
 For GitHub Discussion: create a single "Founding Members" discussion in the repo, @mention neoromantique and nickchomey.
 For emails: send individually, don't CC.
 
 ## Notes
 
-- Swap sponsor link for Polar.sh checkout once #376 is resolved
+- Links now point to Polar.sh checkout (#376 resolved). Founding $5: productId 3f5d75de-936b-49d8-a21b-4b79d9fd22c1
 - Update founding-count in docs/index.html when someone joins
 - Track responses below
+- Anyone not ready to pay → point at the Buttondown subscribe form (lead capture) once the wgmesh newsletter exists
 
 ## Responses
 
 | # | User | Sent | Response |
 |---|------|------|----------|
-| 1 | nycterent | | |
-| 2 | blinkinglight | | |
-| 3 | neoromantique | | |
-| 4 | cablehead | | |
-| 5 | nickchomey | | |
+| 1 | blinkinglight | | |
+| 2 | neoromantique | | |
+| 3 | cablehead | | |
+| 4 | nickchomey | | |

--- a/public/index.html
+++ b/public/index.html
@@ -191,6 +191,18 @@
             }
         }
     </style>
+    <!-- OpenPanel analytics (self-hosted at counter.hackrsvalv.com) -->
+    <script src="https://openpanel.dev/op1.js" defer async></script>
+    <script>
+      window.op = window.op || function(...args) { (window.op.q = window.op.q || []).push(args); };
+      window.op('init', {
+        clientId: '80920d68-b57d-4c7b-baf6-3518495a3739',
+        apiUrl: 'https://counter.hackrsvalv.com/api',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
 </head>
 <body>
     <header>

--- a/wgmesh.dev/index.html
+++ b/wgmesh.dev/index.html
@@ -121,6 +121,18 @@
             }
         }
     </style>
+    <!-- OpenPanel analytics (self-hosted at counter.hackrsvalv.com) -->
+    <script src="https://openpanel.dev/op1.js" defer async></script>
+    <script>
+      window.op = window.op || function(...args) { (window.op.q = window.op.q || []).push(args); };
+      window.op('init', {
+        clientId: '80920d68-b57d-4c7b-baf6-3518495a3739',
+        apiUrl: 'https://counter.hackrsvalv.com/api',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
 </head>
 <body>
     <header>


### PR DESCRIPTION
Updates the dormant outreach so it's actually sendable:
- **Stargazer DMs:** GitHub Sponsors links → live **Polar checkout** (#376 resolved); removed self (nycterent) as target #1 → 4 real external targets (blinkinglight, neoromantique, cablehead, nickchomey).
- **Show HN:** status draft→ready; tier mentions now link Polar checkout ($5 founding + $20 edge node); added pre-post checklist.

Note: target list is thin (4) — needs growing as stars come in. Lead-capture (Buttondown) pending a dedicated wgmesh newsletter.