### PR TITLE
feat(landing): Buttondown subscribe form (meshletter lead capture)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1757,5 +1757,14 @@ fetchPipelineSummary(); // chimney-native endpoint — no GitHub rate limit cost
 setInterval(fetchAll, REFRESH_MS); // 5 min — reduces API call volume to stay within unauthenticated rate limits
 setInterval(fetchPipelineSummary, 60000); // refresh pipeline summary every 60s (server-side cached)
 </script>
+<!-- Buttondown lead capture (meshletter) -->
+<div style="max-width:520px;margin:40px auto;padding:24px;border:1px solid #e5e7eb;border-radius:12px;background:#fafafa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;text-align:center;">
+  <div style="font-size:18px;font-weight:700;color:#111;margin-bottom:6px;">Follow the build</div>
+  <div style="font-size:14px;color:#555;margin-bottom:16px;">Release notes and build log for wgmesh — the zero-control-plane WireGuard mesh. No spam, unsubscribe anytime.</div>
+  <form action="https://buttondown.com/api/emails/embed-subscribe/meshletter" method="post" target="popupwindow" onsubmit="window.open('https://buttondown.com/meshletter', 'popupwindow')" style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap;">
+    <input type="email" name="email" required placeholder="you@example.com" style="flex:1;min-width:220px;padding:10px 12px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;" />
+    <button type="submit" style="padding:10px 18px;border:0;border-radius:8px;background:#2563eb;color:#fff;font-size:14px;font-weight:600;cursor:pointer;">Subscribe</button>
+  </form>
+</div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -252,5 +252,14 @@
         <p>&copy; 2023 wgmesh.dev. All rights reserved.</p>
         <p>Payment via <a href="https://polar.sh/" target="_blank">Polar.sh</a></p> <!-- Added footer link -->
     </footer>
+<!-- Buttondown lead capture (meshletter) -->
+<div style="max-width:520px;margin:40px auto;padding:24px;border:1px solid #e5e7eb;border-radius:12px;background:#fafafa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;text-align:center;">
+  <div style="font-size:18px;font-weight:700;color:#111;margin-bottom:6px;">Follow the build</div>
+  <div style="font-size:14px;color:#555;margin-bottom:16px;">Release notes and build log for wgmesh — the zero-control-plane WireGuard mesh. No spam, unsubscribe anytime.</div>
+  <form action="https://buttondown.com/api/emails/embed-subscribe/meshletter" method="post" target="popupwindow" onsubmit="window.open('https://buttondown.com/meshletter', 'popupwindow')" style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap;">
+    <input type="email" name="email" required placeholder="you@example.com" style="flex:1;min-width:220px;padding:10px 12px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;" />
+    <button type="submit" style="padding:10px 18px;border:0;border-radius:8px;background:#2563eb;color:#fff;font-size:14px;font-weight:600;cursor:pointer;">Subscribe</button>
+  </form>
+</div>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -297,5 +297,14 @@
         <p>&copy; 2024 wgmesh.dev. All rights reserved.</p>
         <p>Powered by WireGuard®. <a href="https://polar.sh/" target="_blank" rel="noopener noreferrer">Payment via Polar.sh</a></p>
     </footer>
+<!-- Buttondown lead capture (meshletter) -->
+<div style="max-width:520px;margin:40px auto;padding:24px;border:1px solid #e5e7eb;border-radius:12px;background:#fafafa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;text-align:center;">
+  <div style="font-size:18px;font-weight:700;color:#111;margin-bottom:6px;">Follow the build</div>
+  <div style="font-size:14px;color:#555;margin-bottom:16px;">Release notes and build log for wgmesh — the zero-control-plane WireGuard mesh. No spam, unsubscribe anytime.</div>
+  <form action="https://buttondown.com/api/emails/embed-subscribe/meshletter" method="post" target="popupwindow" onsubmit="window.open('https://buttondown.com/meshletter', 'popupwindow')" style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap;">
+    <input type="email" name="email" required placeholder="you@example.com" style="flex:1;min-width:220px;padding:10px 12px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;" />
+    <button type="submit" style="padding:10px 18px;border:0;border-radius:8px;background:#2563eb;color:#fff;font-size:14px;font-weight:600;cursor:pointer;">Subscribe</button>
+  </form>
+</div>
 </body>
 </html>

--- a/wgmesh.dev/index.html
+++ b/wgmesh.dev/index.html
@@ -211,5 +211,14 @@
     <footer>
         <p>&copy; 2023 wgmesh.dev. All rights reserved. | <a href="https://polar.sh/" target="_blank" rel="noopener noreferrer" style="color:#007bff; text-decoration:none;">Payment via Polar.sh</a> | <a href="#" style="color:#007bff; text-decoration:none;">Privacy Policy</a> | <a href="#" style="color:#007bff; text-decoration:none;">Terms of Service</a></p>
     </footer>
+<!-- Buttondown lead capture (meshletter) -->
+<div style="max-width:520px;margin:40px auto;padding:24px;border:1px solid #e5e7eb;border-radius:12px;background:#fafafa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;text-align:center;">
+  <div style="font-size:18px;font-weight:700;color:#111;margin-bottom:6px;">Follow the build</div>
+  <div style="font-size:14px;color:#555;margin-bottom:16px;">Release notes and build log for wgmesh — the zero-control-plane WireGuard mesh. No spam, unsubscribe anytime.</div>
+  <form action="https://buttondown.com/api/emails/embed-subscribe/meshletter" method="post" target="popupwindow" onsubmit="window.open('https://buttondown.com/meshletter', 'popupwindow')" style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap;">
+    <input type="email" name="email" required placeholder="you@example.com" style="flex:1;min-width:220px;padding:10px 12px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;" />
+    <button type="submit" style="padding:10px 18px;border:0;border-radius:8px;background:#2563eb;color:#fff;font-size:14px;font-weight:600;cursor:pointer;">Subscribe</button>
+  </form>
+</div>
 </body>
 </html>


### PR DESCRIPTION
Adds an email subscribe form to the 4 landing pages (`index.html`, `public/index.html`, `wgmesh.dev/index.html`, `docs/index.html`), posting to the dedicated **meshletter** Buttondown newsletter (`buttondown.com/api/emails/embed-subscribe/meshletter`, public endpoint, no token).

Captures visitors not ready to pay — pairs with OpenPanel (#762, see clicks) and Polar (buy). Self-contained inline styles, idempotent (1 per file), no external resources beyond the Buttondown POST. Endpoint verified live (subscribe page 200).