### PR TITLE
feat(ci): impl-judge check — fail-closed judge gate for impl PRs (U2)

### DIFF
--- a/.github/workflows/impl-judge.yml
+++ b/.github/workflows/impl-judge.yml
@@ -21,7 +21,9 @@ permissions:
 jobs:
   impl-judge:
     # Only the box's implementation PRs: "fix: Issue #N - ...".
-    if: startsWith(github.event.pull_request.title, 'fix: Issue #')
+    # Quoted whole-value: the inner "fix: Issue #" contains a colon-space that
+    # would otherwise be parsed as a YAML mapping.
+    if: "${{ startsWith(github.event.pull_request.title, 'fix: Issue #') }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR (full history for the base..head diff)

--- a/.github/workflows/impl-judge.yml
+++ b/.github/workflows/impl-judge.yml
@@ -1,0 +1,81 @@
+name: Impl Judge
+
+# Fail-closed DeepSeek judge gate for autonomous impl PRs (judge-gated automerge,
+# U2 of ai-pipeline-template plan 2026-06-20-005). Scores the PR diff against the
+# issue spec for faithfulness + public-safety. The job's pass/fail IS the check:
+# exit 0 = PASS, non-zero = FAIL/error -> blocks merge (the judge is fail-closed,
+# so a provider error or missing spec blocks rather than passes).
+#
+# Activation: set the repo secret OPENROUTER_API_KEY, then make `impl-judge` a
+# required status check on main with auto-merge enabled (U3). Until then this
+# runs as a visible, non-required check (missing key -> exit 2 -> red, but not
+# gating until U3).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  impl-judge:
+    # Only the box's implementation PRs: "fix: Issue #N - ...".
+    if: startsWith(github.event.pull_request.title, 'fix: Issue #')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR (full history for the base..head diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout judge tool (meta-repo, stdlib-only)
+        uses: actions/checkout@v4
+        with:
+          repository: atvirokodosprendimai/ai-pipeline-template
+          path: judge-tool
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Resolve issue, diff, and spec
+        id: prep
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          ISSUE=$(printf '%s' "$PR_TITLE" | sed -n 's/^fix: Issue #\([0-9]\{1,\}\).*/\1/p')
+          [ -n "$ISSUE" ] || { echo "::error::could not parse issue number from title"; exit 1; }
+          echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
+
+          # PR's net change: base..HEAD (HEAD is the PR merge ref under pull_request).
+          git diff "$BASE_SHA"...HEAD > pr.diff
+
+          # Spec lives at specs/issue-N-spec.md — on the PR, on main, or still on a
+          # bot/spec-N branch. Resolve in that order; missing -> empty file ->
+          # the judge fails closed ("missing spec").
+          SPEC="specs/issue-${ISSUE}-spec.md"
+          if [ -f "$SPEC" ]; then
+            cp "$SPEC" spec.md
+          else
+            git fetch --depth 1 origin '+refs/heads/*:refs/remotes/origin/*' || true
+            found=""
+            while read -r ref; do
+              if git cat-file -e "$ref:$SPEC" 2>/dev/null; then found="$ref"; break; fi
+            done < <(git for-each-ref --format='%(refname:short)' refs/remotes/origin)
+            if [ -n "$found" ]; then git show "$found:$SPEC" > spec.md; else : > spec.md; fi
+          fi
+
+      - name: Run impl judge (fail-closed)
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          PYTHONPATH: judge-tool/pipeline
+        run: |
+          set -euo pipefail
+          python -m evals.impl_judge \
+            --diff-file pr.diff \
+            --spec-file spec.md \
+            --issue "${{ steps.prep.outputs.issue }}"


### PR DESCRIPTION
## What

U2 of judge-gated automerge (ai-pipeline-template plan `2026-06-20-005`). Adds `.github/workflows/impl-judge.yml`: on every `fix: Issue #N` PR it runs the **fail-closed DeepSeek judge** (checked out from the ai-pipeline-template meta-repo, stdlib-only) over the PR diff vs `specs/issue-N-spec.md`, scoring **faithfulness** + **public-safety**. The job's pass/fail IS the check — exit 0 = PASS, non-zero = FAIL/error → blocks merge.

Why this replaces the box's distinct-principal/reviewer-PAT approval: the merge gate becomes an objective, fail-closed CI check + GitHub auto-merge — no PAT, no second identity, no 422.

## How it runs
- Checks out the PR (full history) + the meta-repo into `judge-tool/`, `PYTHONPATH=judge-tool/pipeline python -m evals.impl_judge`.
- Resolves the spec from the PR / main / the `bot/spec-N` branch; missing spec → judge fails closed.
- DeepSeek via `OPENROUTER_API_KEY` (a different model family from the GLM-5.2 implementer).

## Activation (operator)
1. Set repo secret **`OPENROUTER_API_KEY`** (DeepSeek via OpenRouter).
2. Make `impl-judge` a **required** status check on `main` + enable **auto-merge** (U3).

Until then this runs as a **visible, non-required** check (no secret → exit 2 → red, but not gating), so landing it is safe.

## Out of scope (follow-ups, plan 2026-06-20-005)
U3 branch-protection + auto-merge, U4 box enables automerge + stops self-merge, U5 retire reviewer-PAT (ai-pipeline-template #1898).