### PR TITLE
ci: add the one CI gate — go build/test/vet, all authors (#1599 retarget)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# The one CI gate for wgmesh: go build / test / vet on every PR and push, for
+# all authors — the autobox is just another developer, its PRs run the same CI
+# a human's does. Secretless (no `secrets.*`, no `pull_request_target`) and
+# forge-portable, mirroring the ai-pipeline-template CI invariant
+# (#1599 retarget; see docs/actions-cicd-only-end-state.md there).
+#
+# Fills the gap where no go build/test ran on PRs (status-check ran make status
+# + lint only; e2e ran on merged bug PRs). impl-judge stays its own workflow: it
+# carries an LLM-judge API secret, so it must stay gated to same-repo bot fix
+# PRs rather than fold into this secretless lane.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test
+
+      - name: Vet
+        run: go vet ./...


### PR DESCRIPTION
## Summary

Adds `ci.yml` — the single CI gate for wgmesh: **go build / test / vet on every PR and push, for all authors**. The autobox is just another developer; its PRs run the same CI a human's does. Secretless (no `secrets.*`, no `pull_request_target`) and forge-portable.

This fills a real gap: there was **no go build/test on PRs** (`status-check` ran `make status` + lint only; `e2e-verifier` ran on merged bug PRs), yet `Auto-merge on CI pass` waits on CI. The seed repo now has a basic correctness gate every PR must pass.

`impl-judge` stays its own workflow — it carries an LLM-judge API secret, so it must stay gated to same-repo bot fix PRs rather than fold into this secretless lane.

Part of the ai-pipeline-template #1599 retarget ("Actions = CI/CD only, autobox is just another developer"); end-state recorded in `docs/actions-cicd-only-end-state.md` there.

## Test plan

- [x] YAML valid; secretless; runs on pull_request + push to main, all authors.
- [ ] CI green on this PR (runs `make build` / `make test` / `go vet ./...`) — surfaces the current state of the go suite.