### PR TITLE
fix(impl-judge): diff PR head against live main, not stale base.sha + merge ref

### DIFF
--- a/.github/workflows/impl-judge.yml
+++ b/.github/workflows/impl-judge.yml
@@ -46,15 +46,23 @@ jobs:
         id: prep
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           ISSUE=$(printf '%s' "$PR_TITLE" | sed -n 's/^fix: Issue #\([0-9]\{1,\}\).*/\1/p')
           [ -n "$ISSUE" ] || { echo "::error::could not parse issue number from title"; exit 1; }
           echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
 
-          # PR's net change: base..HEAD (HEAD is the PR merge ref under pull_request).
-          git diff "$BASE_SHA"...HEAD > pr.diff
+          # The PR's OWN changes only, three-dot against LIVE main using the head
+          # SHA. The old `git diff <event.base.sha>...HEAD` used a STALE base (the
+          # webhook payload's base.sha, frozen at event/rerun time) while HEAD was
+          # the merge ref recomputed against current main — so the diff dragged in
+          # everything main merged since the PR's base (CI workflows, the exit-intent
+          # modal, etc.), making faithful PRs look unfaithful as main drifted under
+          # them. origin/main...head three-dot = merge-base(main, head)..head = just
+          # this PR's changes, matching GitHub's own PR diff.
+          git fetch -q origin main
+          git diff "origin/main...${HEAD_SHA}" > pr.diff
 
           # Spec lives at specs/issue-N-spec.md — on the PR, on main, or still on a
           # bot/spec-N branch. Resolve in that order; missing -> empty file ->


### PR DESCRIPTION
## Problem

The fail-closed `impl-judge` gate was failing **faithful** PRs by grading a **contaminated diff**. Surfaced via `/ce-debug` on #782 (trial signup analytics funnel): a clean 6-file `pkg/analytics/*.go` impl was rejected as *"includes unrelated changes to CI workflows... exit-intent modals."*

Those files weren't a model hallucination — they were **really in the diff the judge computed.**

## Root cause

The "Resolve issue, diff, and spec" step ran:
```bash
git diff "$BASE_SHA"...HEAD > pr.diff   # BASE_SHA = github.event.pull_request.base.sha
```
- `BASE_SHA` is the base tip **frozen in the webhook payload** (and replayed verbatim on a `gh run rerun`) — e.g. `74687545`.
- `HEAD` under `pull_request` is `refs/pull/N/merge` — the head merged into **current** main (e.g. `dd8616b9`).

As main advances under an open PR, `base.sha...merge-ref` (three-dot) widens to include **everything main merged since the PR's base**. Reproduced for #782 — the judge's diff was 12 files: the 6 real analytics files **plus** `.github/workflows/{ci,impl-judge}.yml`, `public/index.html`, `wgmesh.dev/index.html`, `public/wgmesh-quickstart.pdf`. The judge correctly flagged those as unrelated and failed the PR. Accurate judge, polluted input. The pollution is drift-dependent, so it produces flaky false-negatives that worsen as main moves.

## Fix

Diff the PR's **head SHA** three-dot against freshly-fetched **live** `origin/main`:
```bash
git fetch -q origin main
git diff "origin/main...${HEAD_SHA}" > pr.diff
```
`origin/main...head` = `merge-base(main, head)..head` = only this PR's own changes — exactly what GitHub's PR diff shows (the clean 6-file view). Drift under the PR no longer contaminates the judged diff.

## Context

Second of two independent diff-corruptions found this session. The first — `MAX_DIFF_CHARS=16_000` truncating impls mid-hunk — was fixed in ai-pipeline-template #1957. This is the stale-base corruption; together they were blocking faithful PRs from the judge gate. Found via `/ce-debug`.

Verification: re-judging #782 should grade the clean 6 `pkg/analytics/*` files → expected PASS.