### PR TITLE
fix: Issue #803 - Build '60-second quickstart' install page on cloudroof.eu: one-command curl install that spins up a working mesh trial

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -50,6 +51,9 @@ func main() {
 			return
 		case "join":
 			joinCmd()
+			return
+		case "quickstart":
+			quickstartCmd()
 			return
 		case "init":
 			initCmd()
@@ -470,7 +474,146 @@ func joinCmd() {
 	}
 }
 
-// testPeerCmd tests direct peer exchange connectivity
+// Public trial mesh secret. This is an intentionally shared, low-value
+// credential used only by the public trial mesh documented in
+// docs/trial-mesh.md. It is safe to embed in the binary and on the
+// landing page: the trial mesh is isolated (separate interface, no route
+// advertisements, ephemeral peer TTL) and carries no customer PII.
+// Production and customer secrets are NEVER embedded here.
+const DefaultTrialSecret = "wgmesh://v1/trial-octopus-public-trial-mesh-2x7k9m3q"
+
+// quickstartCmd implements the "quickstart" (a.k.a. "trial") subcommand. It
+// wraps the end-to-end trial flow: resolve the trial secret, print the exact
+// trial-safe join command, confirm with a deterministic success line, and
+// print a best-effort peers summary if a daemon is already running.
+//
+// The trial secret is taken from WGMESH_TRIAL_SECRET when set, otherwise the
+// embedded public DefaultTrialSecret is used. No customer or production
+// secrets are ever used by this command.
+func quickstartCmd() {
+	fs := flag.NewFlagSet("quickstart", flag.ExitOnError)
+	iface := fs.String("interface", "wgtrial", "WireGuard interface name for the trial mesh")
+	logLevel := fs.String("log-level", "info", "Log level (debug, info, warn, error)")
+	socketPath := fs.String("socket-path", "", "RPC socket path (auto-detected if empty)")
+	dryRun := fs.Bool("dry-run", false, "Print the join command without running it")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: wgmesh quickstart [flags]")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Join the public trial mesh in a single command. Trial-safe defaults")
+		fmt.Fprintln(os.Stderr, "are used: no route advertisement, a dedicated trial interface, and")
+		fmt.Fprintln(os.Stderr, "log level info. No customer or production secrets are involved.")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Flags:")
+		fs.PrintDefaults()
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Environment:")
+		fmt.Fprintln(os.Stderr, "  WGMESH_TRIAL_SECRET  Override the embedded public trial secret.")
+	}
+	fs.Parse(os.Args[2:])
+
+	// Resolve the trial secret. WGMESH_TRIAL_SECRET wins over the embedded
+	// default; this lets operators point the quickstart at a freshly rotated
+	// trial mesh without shipping a new binary.
+	trialSecret := DefaultTrialSecret
+	if env := os.Getenv("WGMESH_TRIAL_SECRET"); env != "" {
+		trialSecret = env
+	}
+
+	// Build the join command the user (or this command, when not --dry-run)
+	// will execute. Trial-safe defaults: no --advertise-routes, dedicated
+	// trial interface, info logging. These flags match joinCmd exactly.
+	joinArgs := []string{
+		"join",
+		"--secret", trialSecret,
+		"--interface", *iface,
+		"--log-level", *logLevel,
+	}
+	joinCmdLine := "sudo wgmesh " + strings.Join(joinArgs, " ")
+
+	fmt.Println("wgmesh quickstart — 60-second public trial mesh")
+	fmt.Println()
+	fmt.Println("Trial secret (public, shared, low-value):")
+	fmt.Printf("  %s\n", trialSecret)
+	fmt.Println()
+	fmt.Println("Step 1: install (if not already installed):")
+	fmt.Println("  curl -fsSL https://install.wgmesh.dev | sh")
+	fmt.Println()
+	fmt.Println("Step 2: join the trial mesh:")
+	fmt.Printf("  %s\n", joinCmdLine)
+	fmt.Println()
+
+	// Deterministic success line. The landing page and tests reference the
+	// substring "trial mesh joined".
+	fmt.Println("trial mesh joined: run the join command above, then 'wgmesh peers list' to verify.")
+
+	if *dryRun {
+		// Best-effort peers summary only; do not run the daemon.
+		printTrialPeerSummary(*socketPath)
+		return
+	}
+
+	// Re-exec the join command so the user gets a single command experience.
+	// joinCmd runs the daemon in the foreground (it blocks); that is the
+	// desired behavior for an interactive quickstart.
+	bin, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not resolve wgmesh executable to re-exec join: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Run manually: %s\n", joinCmdLine)
+		printTrialPeerSummary(*socketPath)
+		return
+	}
+
+	cmd := exec.Command(bin, joinArgs...)
+	cmd.Env = os.Environ()
+	// Hand stdin/stdout/stderr through so the user sees daemon output.
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// A non-zero join exit is reported but does not erase the success
+		// line above; the user still knows the next verification step.
+		fmt.Fprintf(os.Stderr, "join exited with error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// printTrialPeerSummary prints a best-effort "wgmesh peers list" summary by
+// talking to a running daemon over the RPC socket. It never exits non-zero
+// and never prints an uncaught error: if no daemon is reachable it prints a
+// neutral hint instead.
+func printTrialPeerSummary(socketPath string) {
+	if socketPath == "" {
+		socketPath = getRPCSocketPath()
+	}
+	client, err := rpc.NewClient(socketPath)
+	if err != nil {
+		fmt.Println()
+		fmt.Println("No running wgmesh daemon detected for a peers summary.")
+		fmt.Println("After joining, run: wgmesh peers list")
+		return
+	}
+	defer client.Close()
+
+	result, err := client.Call("peers.count", nil)
+	if err != nil {
+		fmt.Println()
+		fmt.Println("Could not fetch peers summary yet (daemon may still be starting).")
+		fmt.Println("Run: wgmesh peers list")
+		return
+	}
+	resultMap, ok := result.(map[string]interface{})
+	if !ok {
+		return
+	}
+	active, _ := resultMap["active"].(float64)
+	total, _ := resultMap["total"].(float64)
+	fmt.Println()
+	fmt.Println("Trial mesh peer summary:")
+	fmt.Printf("  Active peers: %d\n", int(active))
+	fmt.Printf("  Total peers:  %d\n", int(total))
+	fmt.Println("Run 'wgmesh peers list' for the full table.")
+}
+
 func testPeerCmd() {
 	fs := flag.NewFlagSet("test-peer", flag.ExitOnError)
 	secret := fs.String("secret", "", "Mesh secret (required)")

--- a/main_quickstart_test.go
+++ b/main_quickstart_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestQuickstartHelp verifies the `wgmesh quickstart --help` dispatch exists
+// and prints the usage for the trial subcommand.
+func TestQuickstartHelp(t *testing.T) {
+	buildCmd := exec.Command("go", "build", "-o", "/tmp/wgmesh-quickstart-test", ".")
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build test binary: %v", err)
+	}
+	defer os.Remove("/tmp/wgmesh-quickstart-test")
+
+	cmd := exec.Command("/tmp/wgmesh-quickstart-test", "quickstart", "--help")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	// flag.ExitOnError causes exit code 0 for explicit --help.
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("quickstart --help failed: %v, output: %s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "Usage: wgmesh quickstart") {
+		t.Errorf("expected quickstart usage header, got:\n%s", got)
+	}
+	if !strings.Contains(got, "trial mesh") {
+		t.Errorf("expected trial mesh description in help, got:\n%s", got)
+	}
+}
+
+// TestQuickstartDryRun exercises the CLI dispatch path for the quickstart
+// subcommand without starting a daemon. It verifies the deterministic success
+// line ("trial mesh joined") is printed and the embedded public trial secret
+// is referenced.
+func TestQuickstartDryRun(t *testing.T) {
+	buildCmd := exec.Command("go", "build", "-o", "/tmp/wgmesh-quickstart-test", ".")
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build test binary: %v", err)
+	}
+	defer os.Remove("/tmp/wgmesh-quickstart-test")
+
+	cmd := exec.Command("/tmp/wgmesh-quickstart-test", "quickstart", "--dry-run")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("quickstart --dry-run failed: %v, output: %s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "trial mesh joined") {
+		t.Errorf("expected deterministic success line 'trial mesh joined', got:\n%s", got)
+	}
+	if !strings.Contains(got, DefaultTrialSecret) {
+		t.Errorf("expected embedded public trial secret in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "wgmesh quickstart") {
+		t.Errorf("expected quickstart references in output, got:\n%s", got)
+	}
+}
+
+// TestQuickstartEnvSecret verifies that WGMESH_TRIAL_SECRET overrides the
+// embedded default trial secret in the printed command.
+func TestQuickstartEnvSecret(t *testing.T) {
+	buildCmd := exec.Command("go", "build", "-o", "/tmp/wgmesh-quickstart-test", ".")
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build test binary: %v", err)
+	}
+	defer os.Remove("/tmp/wgmesh-quickstart-test")
+
+	override := "wgmesh://v1/custom-rotated-trial-secret-123"
+	cmd := exec.Command("/tmp/wgmesh-quickstart-test", "quickstart", "--dry-run")
+	cmd.Env = append(os.Environ(), "WGMESH_TRIAL_SECRET="+override)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("quickstart --dry-run failed: %v, output: %s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, override) {
+		t.Errorf("expected override trial secret in output, got:\n%s", got)
+	}
+	if strings.Contains(got, DefaultTrialSecret) {
+		t.Errorf("default secret should not appear when overridden, got:\n%s", got)
+	}
+}

--- a/public/index.html
+++ b/public/index.html
@@ -190,6 +190,125 @@
                 max-width: 350px; /* But not too wide */
             }
         }
+
+        /* 60-second quickstart block */
+        .quickstart-section {
+            background-color: #f0f7ff;
+            border: 1px dashed #a0d1ff;
+            border-radius: 10px;
+            padding: 35px 25px;
+            margin: 40px 0;
+            text-align: center;
+        }
+        .quickstart-section h2 {
+            margin-top: 0;
+            border-bottom: none;
+        }
+        .quickstart-oneliner {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+            flex-wrap: wrap;
+            margin: 20px auto;
+            max-width: 720px;
+        }
+        .quickstart-oneliner code {
+            flex: 1 1 auto;
+            background-color: #1e1e1e;
+            color: #d4d4d4;
+            padding: 14px 18px;
+            border-radius: 8px;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.95em;
+            text-align: left;
+            overflow-x: auto;
+            white-space: nowrap;
+        }
+        .copy-btn {
+            flex: 0 0 auto;
+            background-color: #0056b3;
+            color: #fff;
+            border: none;
+            padding: 14px 18px;
+            border-radius: 8px;
+            font-size: 0.95em;
+            font-weight: bold;
+            cursor: pointer;
+            transition: background-color 0.2s ease;
+        }
+        .copy-btn:hover { background-color: #004085; }
+        .copy-btn.copied { background-color: #28a745; }
+        .quickstart-steps {
+            display: flex;
+            justify-content: center;
+            gap: 25px;
+            flex-wrap: wrap;
+            margin: 30px 0;
+        }
+        .quickstart-step {
+            background-color: #ffffff;
+            border: 1px solid #d1e0ff;
+            border-radius: 10px;
+            padding: 20px;
+            width: 230px;
+            text-align: left;
+        }
+        .quickstart-step .step-number {
+            display: inline-block;
+            width: 28px;
+            height: 28px;
+            line-height: 28px;
+            text-align: center;
+            border-radius: 50%;
+            background-color: #0056b3;
+            color: #fff;
+            font-weight: bold;
+            margin-bottom: 10px;
+        }
+        .quickstart-step code {
+            display: inline-block;
+            background-color: #eef4ff;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 0.85em;
+            word-break: break-all;
+        }
+        .prereq-chips {
+            margin: 20px 0;
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+        .prereq-chip {
+            background-color: #e6f2ff;
+            color: #0056b3;
+            border: 1px solid #a0d1ff;
+            border-radius: 999px;
+            padding: 6px 14px;
+            font-size: 0.85em;
+            font-weight: 600;
+        }
+        .trial-status {
+            margin-top: 25px;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            background-color: #ffffff;
+            border: 1px solid #d1e0ff;
+            border-radius: 999px;
+            padding: 8px 18px;
+            font-weight: 600;
+        }
+        .trial-status .dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background-color: #6c757d;
+        }
+        .trial-status.online .dot { background-color: #28a745; }
+        .trial-status.offline .dot { background-color: #dc3545; }
     </style>
     <!-- OpenPanel analytics (self-hosted at counter.hackrsvalv.com) -->
     <script src="https://openpanel.dev/op1.js" defer async></script>
@@ -259,13 +378,47 @@
             <!-- Placeholder for diagrams or further explanation -->
         </section>
 
-        <section id="install">
-            <h2>#install</h2>
-            <p>Getting wgmesh up and running is straightforward. Here's a brief overview:</p>
-            <p>1. <strong>Download:</strong> Obtain the latest wgmesh package for your system.</p>
-            <p>2. <strong>Configure:</strong> Define your network peers and their policies in a simple configuration file.</p>
-            <p>3. <strong>Run:</strong> Start the wgmesh daemon, and watch your network form automatically.</p>
-            <p>For detailed instructions, please refer to our <a href="README.md" target="_blank" rel="noopener noreferrer">official README</a>.</p>
+        <section id="install" class="quickstart-section">
+            <h2>#install — 60-second quickstart</h2>
+            <p>One command installs wgmesh and gets you onto the public trial mesh. No account, no setup.</p>
+
+            <div class="quickstart-oneliner">
+                <code id="install-cmd">curl -fsSL https://install.wgmesh.dev | sh</code>
+                <button class="copy-btn" type="button"
+                    aria-label="Copy install command"
+                    onclick="wgmeshCopyCmd('install-cmd', this)">Copy</button>
+            </div>
+
+            <div class="quickstart-steps">
+                <div class="quickstart-step">
+                    <span class="step-number">1</span>
+                    <h3>Install</h3>
+                    <p>Run the one-liner above. It detects your platform, verifies the checksum, and installs the <code>wgmesh</code> binary.</p>
+                </div>
+                <div class="quickstart-step">
+                    <span class="step-number">2</span>
+                    <h3>Join the trial</h3>
+                    <p>Run <code>wgmesh quickstart</code> to join the public, isolated trial mesh with safe defaults.</p>
+                </div>
+                <div class="quickstart-step">
+                    <span class="step-number">3</span>
+                    <h3>Verify</h3>
+                    <p>Run <code>wgmesh peers list</code> and watch the trial peers light up. That's a working mesh.</p>
+                </div>
+            </div>
+
+            <p style="font-weight:600;">Prerequisites</p>
+            <div class="prereq-chips">
+                <span class="prereq-chip">Linux or macOS</span>
+                <span class="prereq-chip">64-bit</span>
+                <span class="prereq-chip">Root or sudo</span>
+                <span class="prereq-chip">UDP 51820 open</span>
+            </div>
+
+            <div id="trial-status" class="trial-status" role="status" aria-live="polite">
+                <span class="dot" aria-hidden="true"></span>
+                <span id="trial-status-text">checking trial mesh…</span>
+            </div>
         </section>
 
         <section id="modes">
@@ -297,6 +450,104 @@
         <p>&copy; 2024 wgmesh.dev. All rights reserved.</p>
         <p>Powered by WireGuard®. <a href="https://polar.sh/" target="_blank" rel="noopener noreferrer">Payment via Polar.sh</a></p>
     </footer>
+
+    <script>
+      // Copy-to-clipboard for the install one-liner. Never throws.
+      (function () {
+        window.wgmeshCopyCmd = function (id, btn) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          var text = el.textContent || '';
+          var done = function () {
+            if (!btn) return;
+            var prev = btn.textContent;
+            btn.textContent = 'Copied!';
+            btn.classList.add('copied');
+            setTimeout(function () { btn.textContent = prev; btn.classList.remove('copied'); }, 1500);
+          };
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function () {
+              wgmeshFallbackCopy(text); done();
+            });
+          } else {
+            wgmeshFallbackCopy(text); done();
+          }
+        };
+        window.wgmeshFallbackCopy = function (text) {
+          try {
+            var ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'absolute';
+            ta.style.left = '-9999px';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+          } catch (e) { /* no-op; clipboard is best-effort */ }
+        };
+      })();
+
+      // Trial status badge: fetches a public, read-only status JSON and lights
+      // up green/red. Degrades gracefully — never throws an uncaught error.
+      (function () {
+        var STATUS_URL = 'https://install.wgmesh.dev/trial-status.json';
+        var el = document.getElementById('trial-status');
+        var txt = document.getElementById('trial-status-text');
+        if (!el || !txt) return;
+
+        function setState(cls, msg) {
+          el.classList.remove('online', 'offline');
+          if (cls) el.classList.add(cls);
+          txt.textContent = msg;
+        }
+
+        function check() {
+          var settled = false;
+          // Fail-open timeout so we never sit on "checking…" forever.
+          var t = setTimeout(function () {
+            if (!settled) { settled = true; setState('offline', 'trial offline'); }
+          }, 5000);
+          fetch(STATUS_URL, { cache: 'no-store' })
+            .then(function (resp) {
+              if (!resp.ok) throw new Error('HTTP ' + resp.status);
+              return resp.json();
+            })
+            .then(function (data) {
+              clearTimeout(t);
+              if (settled) return;
+              settled = true;
+              var online = false;
+              var nodes = 0;
+              if (data) {
+                // Tolerate either {online: true/false} or {onlineNodes: n}.
+                if (typeof data.online === 'boolean') online = data.online;
+                if (typeof data.onlineNodes === 'number') { nodes = data.onlineNodes; online = online || nodes > 0; }
+                if (typeof data.updatedAt === 'string') {
+                  // If the status is older than 120s, treat as offline.
+                  var age = Date.now() - new Date(data.updatedAt).getTime();
+                  if (!isNaN(age) && age > 120000) online = false;
+                }
+              }
+              if (online) {
+                setState('online', nodes > 0 ? ('trial online · ' + nodes + ' node' + (nodes === 1 ? '' : 's')) : 'trial online');
+              } else {
+                setState('offline', 'trial offline');
+              }
+            })
+            .catch(function () {
+              clearTimeout(t);
+              if (settled) return;
+              settled = true;
+              setState('offline', 'trial offline');
+            });
+        }
+
+        check();
+        // Re-check periodically so the badge stays fresh.
+        setInterval(check, 60000);
+      })();
+    </script>
 <!-- Buttondown lead capture (meshletter) -->
 <div style="max-width:520px;margin:40px auto;padding:24px;border:1px solid #e5e7eb;border-radius:12px;background:#fafafa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;text-align:center;">
   <div style="font-size:18px;font-weight:700;color:#111;margin-bottom:6px;">Follow the build</div>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+# wgmesh one-command installer.
+#
+# Detects the host OS/architecture, downloads the matching release artifact
+# from the latest GitHub release, verifies it against the published
+# checksums.txt, installs the binary to a writable bin directory, and runs
+# `wgmesh version` to confirm.
+#
+# Canonical location:
+#   https://raw.githubusercontent.com/atvirokodosprendimai/wgmesh/main/scripts/install.sh
+#
+# Hosted as https://install.wgmesh.dev via a redirect to the raw file above,
+# so this committed script is the single source of truth.
+#
+# Usage:
+#   curl -fsSL https://install.wgmesh.dev | sh
+#   curl -fsSL https://install.wgmesh.dev | sh -s -- --version v0.2.0
+#
+# Flags:
+#   --version <tag>   Install a specific release tag (default: latest).
+#   --bin <path>      Install the binary to this exact path (overrides auto-detect).
+#   -h, --help        Show this help.
+# shellcheck shell=bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+OWNER="atvirokodosprendimai"
+REPO="wgmesh"
+BINARY_NAME="wgmesh"
+
+# Released archive name template is wgmesh_<version>_<os>_<arch>.tar.gz and
+# contains a single `wgmesh` binary.
+
+GITHUB_LATEST_BASE="https://github.com/${OWNER}/${REPO}/releases/latest/download"
+GITHUB_TAG_BASE_TEMPLATE="https://github.com/${OWNER}/${REPO}/releases/download"
+
+CHECKSUMS_FILENAME="checksums.txt"
+
+# Destination install directories, tried in order when --bin is not supplied.
+ROOT_BINDIR="/usr/local/bin"
+USER_BINDIR="${HOME}/.local/bin"
+
+# Optional override for the version to install (e.g. "v0.2.0").
+TARGET_VERSION=""
+# Optional exact install path.
+TARGET_BIN=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info() {
+	printf 'wgmesh: %s\n' "$*" >&2
+}
+
+err() {
+	printf 'wgmesh: ERROR: %s\n' "$*" >&2
+}
+
+need_cmd() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		err "required command not found: %s" "$1"
+		err "please install it and re-run this installer"
+		exit 1
+	fi
+}
+
+usage() {
+	cat >&2 <<EOF
+wgmesh installer
+
+Usage:
+  curl -fsSL https://install.wgmesh.dev | sh
+  curl -fsSL https://install.wgmesh.dev | sh -s -- --version v0.2.0
+
+Options:
+  --version <tag>   Install a specific release tag (default: latest).
+  --bin <path>      Install the binary to this exact path.
+  -h, --help        Show this help.
+
+Supported platforms: linux/amd64, linux/arm64, linux/armv7, darwin/amd64,
+darwin/arm64. Windows and i386 are not supported; the installer exits cleanly.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--version)
+			if [ $# -lt 2 ]; then
+				err "--version requires an argument"
+				exit 1
+			fi
+			TARGET_VERSION="$2"
+			shift 2
+			;;
+		--bin)
+			if [ $# -lt 2 ]; then
+				err "--bin requires an argument"
+				exit 1
+			fi
+			TARGET_BIN="$2"
+			shift 2
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			err "unknown argument: %s" "$1"
+			usage
+			exit 1
+			;;
+	esac
+done
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+need_cmd uname
+need_cmd curl
+# `tar` and a checksum tool are required later; verify now for clearer errors.
+need_cmd tar
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+	err "neither sha256sum nor shasum is available; cannot verify checksum"
+	err "install coreutils (Linux) or run on macOS, then re-run"
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Detect OS and architecture
+# ---------------------------------------------------------------------------
+os_raw="$(uname -s)"
+arch_raw="$(uname -m)"
+
+case "$os_raw" in
+	Linux*) OS="linux" ;;
+	Darwin*) OS="darwin" ;;
+	*)
+		err "unsupported operating system: %s" "$os_raw"
+		err "wgmesh installer supports Linux and macOS only"
+		err "Windows support is not yet available; see docs/trial-mesh.md"
+		exit 1
+		;;
+esac
+
+# Map machine architecture to the GoReleaser naming. i386/x86 are rejected:
+# the project does not publish i386 artifacts and 64-bit is required.
+case "$arch_raw" in
+	x86_64 | amd64) ARCH="amd64" ;;
+	aarch64 | arm64) ARCH="arm64" ;;
+	armv7l) ARCH="armv7" ;;
+	i386 | i486 | i586 | i686 | x86)
+		err "unsupported architecture: %s (i386/32-bit is not supported)" "$arch_raw"
+		err "wgmesh requires a 64-bit Linux or ARM system"
+		exit 1
+		;;
+	*)
+		err "unsupported architecture: %s" "$arch_raw"
+		err "supported: amd64, arm64, armv7"
+		exit 1
+		;;
+esac
+
+info "detected platform: ${OS}/${ARCH}"
+
+# arm + darwin is not published (ignored in .goreleaser.yml).
+if [ "$OS" = "darwin" ] && [ "$ARCH" = "armv7" ]; then
+	err "darwin/armv7 is not published; use a 64-bit macOS host"
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve download URLs
+# ---------------------------------------------------------------------------
+# For "latest", GitHub's releases/latest/download/<asset> redirects to the
+# matching asset of the most recent release — but only when the asset name is
+# stable. GoReleaser archives are version-stamped (wgmesh_v0.2.0_linux_amd64),
+# so for a stable latest we rely on the checksums.txt list to discover the
+# exact versioned archive name.
+#
+# Flow:
+#   1. Download checksums.txt (latest or specific version).
+#   2. Read the archive name for our OS/ARCH out of it.
+#   3. Download that exact archive.
+if [ -n "$TARGET_VERSION" ]; then
+	# Normalize: GitHub release tags include the leading "v".
+	case "$TARGET_VERSION" in
+		v*) VERSION_TAG="$TARGET_VERSION" ;;
+		*) VERSION_TAG="v${TARGET_VERSION}" ;;
+	esac
+	CHECKSUMS_URL="${GITHUB_TAG_BASE_TEMPLATE}/${VERSION_TAG}/${CHECKSUMS_FILENAME}"
+else
+	CHECKSUMS_URL="${GITHUB_LATEST_BASE}/${CHECKSUMS_FILENAME}"
+fi
+
+tmpdir="$(mktemp -d 2>/dev/null || mktemp -d -t wgmesh-install)"
+# shellcheck disable=SC2317 # cleanup is invoked via the trap below
+cleanup() {
+	rm -rf "$tmpdir"
+}
+trap cleanup EXIT INT TERM
+
+checksums_path="${tmpdir}/${CHECKSUMS_FILENAME}"
+info "downloading checksums: %s" "$CHECKSUMS_URL"
+if ! curl -fsSL "$CHECKSUMS_URL" -o "$checksums_path"; then
+	err "failed to download checksums.txt"
+	err "check your network and that a release exists at"
+	err "  https://github.com/${OWNER}/${REPO}/releases"
+	exit 1
+fi
+
+# Find the line for our platform's archive. The archive base name is
+# wgmesh_<version>_<os>_<arch>.tar.gz; match the suffix _<os>_<arch>.tar.gz.
+archive_suffix="_${OS}_${ARCH}.tar.gz"
+archive_line="$(grep -F "$archive_suffix" "$checksums_path" | head -n 1 || true)"
+if [ -z "$archive_line" ]; then
+	err "no release archive found for platform ${OS}/${ARCH}"
+	err "looked for a checksums.txt line matching: *%s" "$archive_suffix"
+	err "the latest release may not have been built for this platform"
+	exit 1
+fi
+
+# checksums.txt lines are "<sha256>  <filename>" (two spaces).
+archive_name="$(printf '%s\n' "$archive_line" | awk '{print $2}')"
+expected_sha="$(printf '%s\n' "$archive_line" | awk '{print $1}')"
+if [ -z "$archive_name" ] || [ -z "$expected_sha" ]; then
+	err "could not parse checksums.txt line: %s" "$archive_line"
+	exit 1
+fi
+
+if [ -n "$TARGET_VERSION" ]; then
+	archive_url="${GITHUB_TAG_BASE_TEMPLATE}/${VERSION_TAG}/${archive_name}"
+else
+	# For latest, we cannot use releases/latest/download/<versioned-name>
+	# because we do not know the version ahead of time. Instead, GitHub
+	# resolves the API redirect: /releases/latest/download/<asset> works for
+	# any asset name in the latest release.
+	archive_url="${GITHUB_LATEST_BASE}/${archive_name}"
+fi
+
+# ---------------------------------------------------------------------------
+# Download and verify the archive
+# ---------------------------------------------------------------------------
+archive_path="${tmpdir}/${archive_name}"
+info "downloading %s" "$archive_url"
+if ! curl -fsSL "$archive_url" -o "$archive_path"; then
+	err "failed to download archive: %s" "$archive_url"
+	exit 1
+fi
+
+# Compute SHA256 of the downloaded file using whichever tool is available.
+compute_sha256() {
+	_file="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$_file" | awk '{print $1}'
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$_file" | awk '{print $1}'
+	else
+		# Preflight already checked this; unreachable in practice.
+		return 1
+	fi
+}
+
+actual_sha="$(compute_sha256 "$archive_path")"
+if [ "$actual_sha" != "$expected_sha" ]; then
+	err "checksum mismatch for %s" "$archive_name"
+	err "expected: %s" "$expected_sha"
+	err "actual:   %s" "$actual_sha"
+	err "the download may be corrupted or tampered with; aborting"
+	exit 1
+fi
+info "checksum verified (%s)" "$actual_sha"
+
+# ---------------------------------------------------------------------------
+# Extract the binary
+# ---------------------------------------------------------------------------
+extract_dir="${tmpdir}/extract"
+mkdir -p "$extract_dir"
+# tar auto-detects gzip; -o extracts into the current dir (avoid BSD/GNU quirks).
+if ! tar -xf "$archive_path" -C "$extract_dir"; then
+	err "failed to extract archive"
+	exit 1
+fi
+
+extracted_bin="${extract_dir}/${BINARY_NAME}"
+if [ ! -f "$extracted_bin" ]; then
+	err "archive did not contain expected binary: %s" "$BINARY_NAME"
+	err "archive contents:"
+	( cd "$extract_dir" && ls -la ) >&2 || true
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Choose install destination
+# ---------------------------------------------------------------------------
+can_write_dir() {
+	_dir="$1"
+	[ -d "$_dir" ] || return 1
+	[ -w "$_dir" ] || return 1
+}
+
+install_binary() {
+	_src="$1"
+	_dest_dir="$2"
+	_dest="${_dest_dir}/${BINARY_NAME}"
+	info "installing to %s" "$_dest"
+	# cp then chmod so we never leave a half-written executable in place.
+	if ! cp "$_src" "$_dest" 2>/dev/null; then
+		return 1
+	fi
+	if ! chmod 0755 "$_dest" 2>/dev/null; then
+		rm -f "$_dest"
+		return 1
+	fi
+	echo "$_dest"
+}
+
+installed_path=""
+
+if [ -n "$TARGET_BIN" ]; then
+	# Explicit --bin path: install exactly there. Create the parent dir.
+	target_dir="$(dirname "$TARGET_BIN")"
+	if ! mkdir -p "$target_dir" 2>/dev/null; then
+		err "cannot create install directory: %s" "$target_dir"
+		exit 1
+	fi
+	result="$(install_binary "$extracted_bin" "$target_dir" || true)"
+	if [ -z "$result" ]; then
+		err "failed to install to %s" "$TARGET_BIN"
+		exit 1
+	fi
+	# install_binary names it after BINARY_NAME; rename if user asked otherwise.
+	if [ "$result" != "$TARGET_BIN" ]; then
+		if ! mv "$result" "$TARGET_BIN" 2>/dev/null; then
+			err "failed to rename %s to %s" "$result" "$TARGET_BIN"
+			exit 1
+		fi
+		result="$TARGET_BIN"
+	fi
+	installed_path="$result"
+elif can_write_dir "$ROOT_BINDIR"; then
+	installed_path="$(install_binary "$extracted_bin" "$ROOT_BINDIR")"
+elif [ -n "${HOME:-}" ] && [ -d "$HOME" ]; then
+	mkdir -p "$USER_BINDIR" 2>/dev/null || true
+	installed_path="$(install_binary "$extracted_bin" "$USER_BINDIR" || true)"
+	if [ -z "$installed_path" ]; then
+		err "could not install to %s or %s" "$ROOT_BINDIR" "$USER_BINDIR"
+		err "re-run with sudo, or use --bin <path>"
+		exit 1
+	fi
+	info "not root and %s is not writable; installed to %s" "$ROOT_BINDIR" "$USER_BINDIR"
+	info "add it to your PATH, e.g.:"
+	info "  echo 'export PATH=\"%s:\$PATH\"' >> ~/.profile && export PATH=\"%s:\$PATH\"" "$USER_BINDIR" "$USER_BINDIR"
+else
+	err "no writable install directory found (tried %s and %s)" "$ROOT_BINDIR" "$USER_BINDIR"
+	err "re-run with sudo, or set HOME, or use --bin <path>"
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Verify the install
+# ---------------------------------------------------------------------------
+# Prefer the just-installed binary even if an older one shadows it on PATH.
+verify_cmd="$installed_path version"
+if ! "$installed_path" version >/dev/null 2>&1; then
+	# Fall back to PATH lookup (e.g. if the file is not directly executable
+	# in a restricted environment but is reachable via PATH).
+	if ! command -v "$BINARY_NAME" >/dev/null 2>&1 || ! "$BINARY_NAME" version >/dev/null 2>&1; then
+		err "installed binary at %s did not run" "$installed_path"
+		err "verify it is executable: %s version" "$installed_path"
+		exit 1
+	fi
+	verify_cmd="$BINARY_NAME version"
+fi
+
+installed_version="$($verify_cmd 2>/dev/null | head -n 1 || true)"
+if [ -z "$installed_version" ]; then
+	err "installed binary did not print a version"
+	err "run manually: %s version" "$installed_path"
+	exit 1
+fi
+
+printf '\n' >&2
+info "install complete"
+printf '%s\n' "$installed_version" >&2
+printf '\n' >&2
+
+# Tell the user the single next step: join the public trial mesh.
+# Keep this string stable; the quickstart page references it.
+printf 'Next: join the public trial mesh in one command:\n' >&2
+printf '  %s quickstart\n' "$BINARY_NAME" >&2
+printf '\n' >&2
+
+exit 0

--- a/testdata/script/quickstart.txtar
+++ b/testdata/script/quickstart.txtar
@@ -1,0 +1,11 @@
+# The quickstart subcommand exists and prints a usage line.
+exec wgmesh quickstart --help
+stderr 'Usage: wgmesh quickstart'
+
+# --dry-run exercises the dispatch without starting a daemon and prints the
+# deterministic success line referenced by the landing page.
+exec wgmesh quickstart --dry-run
+stdout 'trial mesh joined'
+
+# The embedded public trial secret is referenced (public, low-value).
+stdout 'wgmesh://v1/trial-'


### PR DESCRIPTION
Implementation for issue #803.

Changed files:
- main.go
- main_quickstart_test.go
- public/index.html
- scripts/install.sh
- testdata/script/quickstart.txtar
