### PR TITLE
fix(analytics): resolve Event/EventType redeclaration that broke main

### DIFF
--- a/pkg/analytics/logger.go
+++ b/pkg/analytics/logger.go
@@ -15,7 +15,7 @@ import (
 type Logger struct {
 	mu      sync.Mutex
 	path    string // Path to event log file
-	buffer  []Event
+	buffer  []ConversionEvent
 	bufSize int // Buffer size before flush
 	flushed int // Number of events flushed
 }
@@ -45,7 +45,7 @@ func NewLogger(cfg LoggerConfig) (*Logger, error) {
 	l := &Logger{
 		path:    path,
 		bufSize: bufSize,
-		buffer:  make([]Event, 0, bufSize),
+		buffer:  make([]ConversionEvent, 0, bufSize),
 	}
 
 	return l, nil
@@ -53,7 +53,7 @@ func NewLogger(cfg LoggerConfig) (*Logger, error) {
 
 // Log records an analytics event.
 // Events are buffered and flushed to disk when the buffer is full.
-func (l *Logger) Log(event Event) error {
+func (l *Logger) Log(event ConversionEvent) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -122,7 +122,7 @@ func (l *Logger) flush() error {
 
 // LogTrialSignup records a trial signup event.
 func (l *Logger) LogTrialSignup(code, campaignID, source, accountID string) error {
-	return l.Log(Event{
+	return l.Log(ConversionEvent{
 		Type: EventTrialSignup,
 		Properties: map[string]string{
 			PropCode:       code,
@@ -135,7 +135,7 @@ func (l *Logger) LogTrialSignup(code, campaignID, source, accountID string) erro
 
 // LogTrialActivation records a trial activation event.
 func (l *Logger) LogTrialActivation(accountID string) error {
-	return l.Log(Event{
+	return l.Log(ConversionEvent{
 		Type: EventTrialActivation,
 		Properties: map[string]string{
 			PropAccountID: accountID,
@@ -145,7 +145,7 @@ func (l *Logger) LogTrialActivation(accountID string) error {
 
 // LogTrialConversion records a trial conversion event.
 func (l *Logger) LogTrialConversion(accountID string) error {
-	return l.Log(Event{
+	return l.Log(ConversionEvent{
 		Type: EventTrialConversion,
 		Properties: map[string]string{
 			PropAccountID: accountID,
@@ -155,7 +155,7 @@ func (l *Logger) LogTrialConversion(accountID string) error {
 
 // LogPromoRedeemed records a promo redemption event.
 func (l *Logger) LogPromoRedeemed(code, campaignID, accountID string) error {
-	return l.Log(Event{
+	return l.Log(ConversionEvent{
 		Type: EventPromoRedeemed,
 		Properties: map[string]string{
 			PropCode:       code,
@@ -167,7 +167,7 @@ func (l *Logger) LogPromoRedeemed(code, campaignID, accountID string) error {
 
 // LogCommunityClick records a click-through from community outreach.
 func (l *Logger) LogCommunityClick(communityID, source, url string) error {
-	return l.Log(Event{
+	return l.Log(ConversionEvent{
 		Type: EventCommunityClick,
 		Properties: map[string]string{
 			PropCommunityID: communityID,
@@ -178,6 +178,6 @@ func (l *Logger) LogCommunityClick(communityID, source, url string) error {
 }
 
 // generateEventID creates a unique event ID.
-func generateEventID(event Event) string {
+func generateEventID(event ConversionEvent) string {
 	return fmt.Sprintf("%s-%d", event.Type, time.Now().UnixNano())
 }

--- a/pkg/analytics/logger_test.go
+++ b/pkg/analytics/logger_test.go
@@ -55,7 +55,7 @@ func TestLog(t *testing.T) {
 	t.Run("logs event", func(t *testing.T) {
 		logger := tempLogger(t)
 
-		event := Event{
+		event := ConversionEvent{
 			Type:      EventTrialSignup,
 			Timestamp: time.Now(),
 			Properties: map[string]string{
@@ -76,7 +76,7 @@ func TestLog(t *testing.T) {
 	t.Run("assigns ID if missing", func(t *testing.T) {
 		logger := tempLogger(t)
 
-		event := Event{
+		event := ConversionEvent{
 			Type: EventTrialSignup,
 		}
 
@@ -93,7 +93,7 @@ func TestLog(t *testing.T) {
 	t.Run("assigns timestamp if missing", func(t *testing.T) {
 		logger := tempLogger(t)
 
-		event := Event{
+		event := ConversionEvent{
 			Type: EventTrialSignup,
 			ID:   "test-id",
 		}
@@ -115,7 +115,7 @@ func TestFlush(t *testing.T) {
 
 		// Log 5 events (buffer size is 5)
 		for i := 0; i < 5; i++ {
-			err := logger.Log(Event{Type: EventTrialSignup})
+			err := logger.Log(ConversionEvent{Type: EventTrialSignup})
 			if err != nil {
 				t.Fatalf("Log() failed: %v", err)
 			}
@@ -142,7 +142,7 @@ func TestFlush(t *testing.T) {
 
 		// Log 2 events to trigger flush
 		for i := 0; i < 2; i++ {
-			err := logger.Log(Event{
+			err := logger.Log(ConversionEvent{
 				Type: EventTrialSignup,
 				Properties: map[string]string{
 					PropAccountID: fmt.Sprintf("account-%d", i),
@@ -170,7 +170,7 @@ func TestFlush(t *testing.T) {
 		}
 
 		// Parse and verify first event
-		var event Event
+		var event ConversionEvent
 		if err := json.Unmarshal([]byte(lines[0]), &event); err != nil {
 			t.Fatalf("Unmarshal() failed: %v", err)
 		}
@@ -183,7 +183,7 @@ func TestFlush(t *testing.T) {
 	t.Run("manual flush", func(t *testing.T) {
 		logger := tempLogger(t)
 
-		err := logger.Log(Event{Type: EventTrialSignup})
+		err := logger.Log(ConversionEvent{Type: EventTrialSignup})
 		if err != nil {
 			t.Fatalf("Log() failed: %v", err)
 		}

--- a/pkg/analytics/metrics.go
+++ b/pkg/analytics/metrics.go
@@ -46,7 +46,7 @@ func (c *Calculator) ComputeCampaignMetrics(campaignID string) (*CampaignMetrics
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		var event Event
+		var event ConversionEvent
 		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
 			continue // Skip malformed lines
 		}
@@ -99,7 +99,7 @@ func (c *Calculator) ComputeFunnelMetrics() (*ConversionFunnel, error) {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		var event Event
+		var event ConversionEvent
 		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
 			continue
 		}

--- a/pkg/analytics/metrics_test.go
+++ b/pkg/analytics/metrics_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func tempLogWithEvents(t *testing.T, events []Event) string {
+func tempLogWithEvents(t *testing.T, events []ConversionEvent) string {
 	t.Helper()
 
 	tmpDir := t.TempDir()
@@ -31,7 +31,7 @@ func tempLogWithEvents(t *testing.T, events []Event) string {
 }
 
 func TestComputeCampaignMetrics(t *testing.T) {
-	events := []Event{
+	events := []ConversionEvent{
 		{
 			Type: EventPromoRedeemed,
 			Properties: map[string]string{
@@ -137,7 +137,7 @@ func TestComputeCampaignMetricsNoEvents(t *testing.T) {
 }
 
 func TestComputeFunnelMetrics(t *testing.T) {
-	events := []Event{
+	events := []ConversionEvent{
 		{Type: EventTrialSignup},
 		{Type: EventTrialSignup},
 		{Type: EventTrialSignup},

--- a/pkg/analytics/types.go
+++ b/pkg/analytics/types.go
@@ -2,23 +2,23 @@ package analytics
 
 import "time"
 
-// EventType represents the type of analytics event.
-type EventType string
+// ConversionEventType represents the type of analytics event.
+type ConversionEventType string
 
 const (
-	EventTrialSignup     EventType = "trial_signup"
-	EventTrialActivation EventType = "trial_activation"
-	EventTrialConversion EventType = "trial_conversion"
-	EventPromoRedeemed   EventType = "promo_redeemed"
-	EventCommunityClick  EventType = "community_click"
+	EventTrialSignup     ConversionEventType = "trial_signup"
+	EventTrialActivation ConversionEventType = "trial_activation"
+	EventTrialConversion ConversionEventType = "trial_conversion"
+	EventPromoRedeemed   ConversionEventType = "promo_redeemed"
+	EventCommunityClick  ConversionEventType = "community_click"
 )
 
-// Event represents an analytics event for tracking trials and conversions.
-type Event struct {
+// ConversionEvent represents an analytics event for tracking trials and conversions.
+type ConversionEvent struct {
 	ID         string            // Unique event ID
-	Type       EventType         // Event type
+	Type       ConversionEventType         // ConversionEvent type
 	Timestamp  time.Time         // When the event occurred
-	Properties map[string]string // Event properties
+	Properties map[string]string // ConversionEvent properties
 }
 
 // Common property keys


### PR DESCRIPTION
## Problem

`main` does not compile. Two analytics implementations landed in `pkg/analytics` in the same merge window and collided — both declared `type Event` and `type EventType`:

```
pkg/analytics/types.go:6:6: EventType redeclared in this block
        pkg/analytics/events.go:14:6: other declaration of EventType
pkg/analytics/types.go:17:6: Event redeclared in this block
pkg/analytics/logger.go:127:3: unknown field Properties in struct literal of type Event
FAIL github.com/atvirokodosprendimai/wgmesh/pkg/analytics [build failed]
```

Because main is broken, `build-test` (go build/test/vet) goes **red on every open PR** — including spec-only PRs with zero Go changes — so the autonomous merge lane is **frozen** (PRs sit MERGEABLE/UNSTABLE, never auto-merge).

## Two colliding clusters

- **events.go** — rich trial-funnel model: `Tracker`/`Handler`, `Event{SessionID, Metadata, Error}`, 8 funnel-stage event types. Consumers: memory.go, log.go, postgres.go.
- **types.go** — simpler conversion model: `Event{Properties map[string]string}`, consumed by `Logger` (logger.go), `Calculator` (metrics.go), and `ConversionFunnel`. External consumer `cmd/analytics-dashboard` uses `Calculator`/`ConversionFunnel` only.

## Fix

Rename the **simpler** cluster's two colliding types to `ConversionEvent` / `ConversionEventType` (pairs with its existing `ConversionFunnel`). Lowest churn — touches only `types.go`, `logger.go`, `metrics.go` and their tests. The `Tracker` subsystem and `cmd/analytics-dashboard` are untouched. No JSON-shape change (neither Event had/needs struct tags), so existing `analytics.log` files still parse.

## Verification

`go build ./...`, `go vet ./pkg/analytics/`, `go test ./...` — all pass (18 packages ok).

## Follow-up (not in this PR)

Per-PR `build-test` validates each PR's own merge-ref; nothing validates the **combined** post-merge main. A fast-merge burst let two per-PR-green impls collide. A merge-queue or post-merge main-health gate would prevent recurrence.